### PR TITLE
Added parse_time_info method.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,5 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* [tbaugis](https://github.com/tbaugis): `parse_time_info` from [hamster-cli](
+  https://github.com/projecthamster/hamster/blob/master/src/hamster-cli)

--- a/hamsterlib/lib.py
+++ b/hamsterlib/lib.py
@@ -63,6 +63,114 @@ class HamsterControl(object):
         return lib_logger
 
 
+    def parse_time_info(self, time_info):
+        """
+        Generic parser for time(-range) information.
+
+        Note:
+            * We assume that timedeltas are relative to ``now``.
+            * Relative times always return just ``(start, None)``.
+            * It seems that the original implementation behaves rather weired
+              with regards to the end-datetime fallback. When there is no
+              end-date we try using the start date. If there is no start date
+              we use today. However, at this point it is not quite clear
+              what an enddate without an start date is supposed to mean.
+              Should we rather throw an exception?
+
+        Args:
+            time_info (str): Time(-range) information. Space seperated list of
+                [start-date] [start-time] [end-date] [end-time].
+
+        Returns:
+            tuple(): Tuple of (start, end) datetime objects. Each may be
+                ``None``.
+        """
+        def get_time(time, fallback):
+            """
+            Convert a time string to a ``datetime.time`` instance.
+
+            Note:
+                Besides the regular builtin functionality this also handeles
+                our fallback behaviour for empty strings.
+
+            Args:
+                time (str): Date in the format "hh:mm".
+                fallback (datetime.time()): Fallback, if no time is specified.
+
+            Returns:
+                datetime.time(): ``time`` instance or ``None``.
+            """
+            result = fallback
+            if time:
+                result = datetime.datetime.strptime(time.strip(), "%H:%M").time()
+            return result
+
+        def get_date(date, fallback):
+            """
+            Convert a date string to a ``datetime.date`` instance.
+
+            In addition to the builtin method we this also handles empty
+            strings.
+
+            Args:
+                date (str): Date in the format "yyyy-mm-dd"
+                fallback (datetime.date()): Fallback, if no date is specified.
+
+            Returns:
+                datetime.date(): ``date`` instance or ``None``.
+            """
+            result = fallback
+            if date:
+                result = datetime.datetime.strptime(date.strip(), "%Y-%m-%d").date()
+            return result
+
+        patterns = (
+            '^((?P<relative>-\d.+)?|('
+            '(?P<date1>\d{4}-\d{2}-\d{2})?'
+            '(?P<time1> ?\d{2}:\d{2})?'
+            '(?P<dash> ?-)?'
+            '(?P<date2> ?\d{4}-\d{2}-\d{2})?'
+            '(?P<time2> ?\d{2}:\d{2})?)?)'
+            '(?P<rest>\D.+)?$'
+        )
+        match = re.compile(patterns).match(time_info)
+
+        if not match:
+            result = (None, None)
+        else:
+            fragments = match.groupdict()
+            rest = (fragments['rest'] or '').strip()
+
+            # Bail out early on relative minutes
+            if fragments['relative']:
+                delta = datetime.timedelta(minutes=int(fragments['relative']))
+                result = (datetime.datetime.now() - delta, None)
+            else:
+                start, end = None, None
+
+                start_date = fragments.get('date1', None)
+                start_time = fragments.get('time1', None)
+
+                end_date = fragments.get('date2', None)
+                end_time = fragments.get('time2', None)
+
+                if start_date or start_time:
+                    # Only  one of the two fallbacks should trigger at max!
+                    start_date = get_date(start_date, datetime.date.today())
+                    start = datetime.datetime.combine(
+                        start_date,
+                        get_time(start_time, datetime.time())
+                    )
+
+                if end_date or end_time:
+                    # Only  one of the two fallbacks should trigger at max!
+                    end = datetime.datetime.combine(
+                        get_date(end_date, start_date),
+                        get_time(end_time, datetime.time())
+                    )
+                result = (start, end)
+        return result
+
 
     def parse_raw_fact(self, raw_fact):
         """
@@ -129,27 +237,10 @@ class HamsterControl(object):
 
         def parse_time_info(string):
             """
-            According to current understannding we check for one of three
-            options:
-                * We get (only) a timedelta (in minutes?): - XYZ (max 3 digits)
-                * We get a (date)-time: HH:MM
-                * We get a timespan: HH:MM - HH:MM
-
-            It aprears that the current backend raw_fact parsing originaly found
-            in hamster.lib.__ini__.Fact.parse_fact() only allows to detect and
-            process <TIME>. There seems to be no consideration for <DATE> what
-            so ever. A more comprehensive parser can be found in recent versions
-            of hamster-cli.
-
             Eventually all parsing should happen by hamsterlib, so that this
             functionality does not have to be replicated by all frontends
             (originaly I was/am a great fan of 'parsing and handing over
             valid/typed input is a frontend job').
-
-            It is also worth noting that hamster-clis regex pattern is much nicer
-            (using named groups) and seems lack hackish.
-            For now, to limit the scope of this refactor, however we stick the
-            original.
 
             Returns (start_time, end_time) as datetime.datetime objects,
             where end_time may be None.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,14 +322,51 @@ def raw_fact_with_persistent_activity(persistent_activity):
     )
 
 
-
-
 @pytest.fixture
 def start_end_times():
     """Return a start/end-datetime-tuple."""
     end = datetime.datetime.now().time()
     start = end - datetime.timedelta(minutes=15)
     return (start, end)
+
+@pytest.fixture(params=[
+    ('2015-12-12', (datetime.datetime(2015, 12, 12, 0, 0, 0), None)),
+    ('   2015-12-12    ', (None, None)),
+    ('2015-12-12 12:30', (datetime.datetime(2015, 12, 12, 12, 30, 0), None)),
+    ('2015-12-12    12:30', (datetime.datetime(2015, 12, 12, 0, 0, 0), None)),
+    ('12:30', (convert_time_to_datetime('12:30'), None)),
+    ('   12:30', (None, None)),
+    ('12:30   ', (convert_time_to_datetime('12:30'), None)),
+    ('2015-12-12 2015-12-20', (
+        datetime.datetime(2015, 12, 12, 0, 0, 0),
+        datetime.datetime(2015, 12, 20, 0, 0, 0)
+    )),
+    ('2015-12-12      2015-12-20', (
+        datetime.datetime(2015, 12, 12, 0, 0, 0),
+        None,
+    )),
+    ('   2015-12-12 2015-12-20', ( None, None)),
+    ('2015-12-12 2015-12-20     ', (
+        datetime.datetime(2015, 12, 12, 0, 0, 0),
+        datetime.datetime(2015, 12, 20, 0, 0, 0)
+    )),
+    ('2015-12-12 2015-12-20 12:30', (
+        datetime.datetime(2015, 12, 12, 0, 0, 0),
+        datetime.datetime(2015, 12, 20, 12, 30, 0)
+    )),
+    ('2015-12-12 10:33 2015-12-20 12:30', (
+        datetime.datetime(2015, 12, 12, 10, 33, 0),
+        datetime.datetime(2015, 12, 20, 12, 30, 0)
+    )),
+    ('10:33 12:30', (
+        convert_time_to_datetime('10:33'),
+        convert_time_to_datetime('12:30')
+    )),
+
+])
+def time_info_string(request):
+    """Return a time info string the return value by parse_time_info."""
+    return request.param
 
 
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -38,6 +38,11 @@ class TestControler:
             controler.parse_raw_fact(invalid_raw_fact)
 
 
+    def test_parse_time_info(self, controler, time_info_string):
+        string, expectation = time_info_string
+        assert controler.parse_time_info(string) == expectation
+
+
     def test_parse_raw_fact_with_persistent_activity(self, controler,
         raw_fact_with_persistent_activity):
         raw_fact, expectation = raw_fact_with_persistent_activity


### PR DESCRIPTION
This method mimics `legacy hamser-cli` way of disassembling time
information.

Also:
- Cleaned up `parse_raw_fact` method docstring after information moved
  to wiki.
- Gave credit to tbaugis for the original parse_time_info function.

Closes #25 
