### PR TITLE
Added 'complete_timeframe' helper function.

### DIFF
--- a/hamsterlib/helpers.py
+++ b/hamsterlib/helpers.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import re
 import datetime
+from gettext import gettext as _
 
 
 TimeFrame = namedtuple('Timeframe', ('start_date', 'start_time',
@@ -54,4 +55,70 @@ def parse_time_info(time_info):
                 offset=None
             )
     return result
+
+
+def complete_timeframe(timeframe, day_start):
+    """Apply fallback strategy to incomplete timeframes."""
+
+    def complete_start_date(date):
+        if not date:
+            date = datetime.date.today()
+        else:
+            if not isinstance(date, datetime.date):
+                raise TypeError(_(
+                    "Expected datetime.date instance, got {type} instead.".format(
+                        type=type(date))
+                ))
+        return date
+
+    def complete_start_time(time, day_start):
+        if not time:
+            time = day_start
+        else:
+            if not isinstance(time, datetime.time):
+                raise TypeError(_(
+                    "Expected datetime.time instance, got {type} instead.".format(
+                        type=type(time))
+                ))
+        return time
+
+    def complete_end_date(date, start_date):
+        if not date:
+            date = start_date + datetime.timedelta(days=1)
+        else:
+            if not isinstance(date, datetime.date):
+                raise TypeError(_(
+                    "Expected datetime.date instance, got {type} instead.".format(
+                        type=type(date))
+                ))
+        return date
+
+    def complete_end_time(time, start_time):
+        if not time:
+            # create a pseudo datetime object so we can operate with timedelta
+            time = datetime.datetime.combine(datetime.date.today(),
+                start_time)
+            time = (time - datetime.timedelta(seconds=1)).time()
+        else:
+            if not isinstance(time, datetime.time):
+                raise TypeError(_(
+                    "Expected datetime.time instance, got {type} instead.".format(
+                        type=type(time))
+                ))
+        return time
+
+
+    if not timeframe.offset:
+        start = datetime.datetime.combine(
+            complete_start_date(timeframe.start_date),
+            complete_start_time(timeframe.start_time, day_start),
+        )
+    else:
+        start = datetime.datetime.now() - timeframe.offset
+
+    end = datetime.datetime.combine(
+        complete_end_date(timeframe.end_date, start.date()),
+        complete_end_time(timeframe.end_time, start.time())
+    )
+    return (start, end)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,7 @@ def base_config():
     return {
         'unsorted_localized': 'Unsorted',
         'store': 'sqlalchemy',
-        'daystart': datetime.time(hour=0, minute=0, second=0),
-        'dayend': datetime.time(hour=23, minute=59, second=59),
+        'day_start': datetime.time(hour=5, minute=30, second=0),
         'db-path': 'sqlite:///:memory:',
     }
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 import datetime
 import pytest
 from hamsterlib import helpers
+from freezegun import freeze_time
 
 
 
@@ -41,6 +42,52 @@ from hamsterlib import helpers
         offset=datetime.timedelta(minutes=85)
     )),
 ])
-def test_parse_time_info(controler, time_info, expectation):
+def test_parse_time_info(time_info, expectation):
     assert helpers.parse_time_info(time_info) == expectation
+
+
+@pytest.mark.parametrize(('timeframe', 'expectation'), [
+    (
+        helpers.TimeFrame(
+            start_date=None,
+            start_time=None,
+            end_date=None,
+            end_time=None,
+            offset=datetime.timedelta(minutes=90)
+        ),
+        (
+            datetime.datetime(2015, 12, 10, 11, 0, 0),
+            datetime.datetime(2015, 12, 11, 10, 59, 59)
+        ),
+    ),
+    (
+        helpers.TimeFrame(
+            start_date=None,
+            start_time=None,
+            end_date=None,
+            end_time=None,
+            offset=None
+        ),
+        (
+            datetime.datetime(2015, 12, 10, 5, 30, 0),
+            datetime.datetime(2015, 12, 11, 5, 29, 59)
+        ),
+    ),
+    (
+        helpers.TimeFrame(
+            start_date=datetime.date(2015, 12, 1),
+            start_time=None,
+            end_date=datetime.date(2015, 12, 4),
+            end_time=None,
+            offset=None
+        ),
+        (
+            datetime.datetime(2015, 12, 1, 5, 30, 0),
+            datetime.datetime(2015, 12, 4, 5, 29, 59)
+        ),
+    ),
+])
+@freeze_time('2015-12-10 12:30')
+def test_complete_timeframe_valid(base_config, timeframe, expectation):
+    assert helpers.complete_timeframe(timeframe, base_config['day_start']) == expectation
 


### PR DESCRIPTION
This helper function provides a clean and easy to customize central way to define our fallback behaviour for timeframe related functionality.
We are fully transparent with regards to our configs `day_start` setting. each auto generated start/end-time will start just at the defined beginning of the day and end just one the last second of our end day.
Whilst respecting our fallback settings, this solution will also respect any explicit time settings so our clients are free to specify timeframes with utmost flexibility if they want to.

Closes #35 
