### PR TITLE
Stop bumpversion creating tags

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.1.0
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:setup.py]
 


### PR DESCRIPTION
This PR stops bumpversion from automatically creating tags.

Closes: #126 