### PR TITLE
Remove 'Fact.serialized_name' property and __repr__

### DIFF
--- a/hamster_lib/backends/sqlalchemy/storage.py
+++ b/hamster_lib/backends/sqlalchemy/storage.py
@@ -197,13 +197,10 @@ class CategoryManager(storage.BaseCategoryManager):
         message = _("Recieved {!r} and raw={}.".format(category, raw))
         self.store.logger.debug(message)
 
-        if category:
-            try:
-                category = self.get_by_name(category.name, raw=raw)
-            except KeyError:
-                category = self._add(category, raw=raw)
-        else:
-            category = None
+        try:
+            category = self.get_by_name(category.name, raw=raw)
+        except KeyError:
+            category = self._add(category, raw=raw)
         return category
 
     def _add(self, category, raw=False):

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -593,36 +593,6 @@ class Fact(object):
         return self.start.date()
 
     @property
-    def serialized_name(self):
-        """
-        Provide a string representation of this fact.
-
-        Returns:
-            str: String serializing all relevant fields of this fact.
-
-        Note:
-            * Pattern: [<start>-<end>] <activity_name>[@<category_name>, <description_text>]
-            * Time format information from hamster-cli:
-                * 'YYYY-MM-DD hh:mm:ss': If date is missing, it will default to today.
-                    If time is missing, it will default to 00:00 for start time and 23:59 for
-                    end time.
-                * '-minutes': Relative time in minutes from the current date and time.
-            * Our version of this method does not contain time information!
-        """
-        result = text_type(self.activity.name)
-
-        if self.category:
-            result += "@%s" % self.category.name
-
-        if self.description or self.tags:
-            # [FIXME]
-            # Workaround until we address tags!
-            result += ', {}'.format(self.description or "")
-            # result += "%s, %s" % (" ".join(["#%s" % tag for tag in self.tags]),
-            #                    self.description or "")
-        return result
-
-    @property
     def category(self):
         """For convenience only."""
         return self.activity.category
@@ -669,13 +639,27 @@ class Fact(object):
         return self.as_tuple() == other
 
     def __str__(self):
-        time = self.start.strftime("%d-%m-%Y %H:%M")
-        if self.end:
-            time = "%s - %s" % (time, self.end.strftime("%H:%M"))
-        return "%s %s" % (time, self.serialized_name)
+        result = text_type(self.activity.name)
 
-    def __repr__(self):
-        time = self.start.strftime("%d-%m-%Y %H:%M")
+        if self.category:
+            result += "@%s" % text_type(self.category.name)
+
+        if self.description or self.tags:
+            # [FIXME]
+            # Workaround until we address tags!
+            result += ', {}'.format(text_type(self.description) or '')
+            # result += "%s, %s" % (" ".join(["#%s" % tag for tag in self.tags]),
+            #                    self.description or "")
+
+        if self.start:
+            start = text_type(self.start.strftime("%d-%m-%Y %H:%M"))
+
         if self.end:
-            time = str('%s - %s') % (time, self.end.strftime("%H:%M"))
-        return str('%s %s') % (time, repr(self.serialized_name))
+            end = text_type(self.end.strftime("%d-%m-%Y %H:%M"))
+
+        if self.start and self.end:
+            result = '{} to {} {}'.format(start, end, result)
+        elif self.start and not self.end:
+            result = '{} {}'.format(start, result)
+
+        return result

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -111,9 +111,17 @@ class TestCategoryManager():
         assert category.equal_fields(db_instance)
 
     def test_update_without_pk(self, alchemy_store, alchemy_category_factory):
+        """Make sure that passing a category without a PK raises an error."""
         category = alchemy_category_factory().as_hamster()
         category.pk = None
         with pytest.raises(ValueError):
+            alchemy_store.categories._update(category)
+
+    def test_update_invalid_pk(self, alchemy_store, alchemy_category_factory):
+        """Make sure that passing a category with a non existing PK raises an error."""
+        category = alchemy_category_factory().as_hamster()
+        category.pk = category.pk + 10
+        with pytest.raises(KeyError):
             alchemy_store.categories._update(category)
 
     def test_update_existing_name(self, alchemy_store, alchemy_category_factory):

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -257,23 +257,6 @@ class TestFact(object):
         """Make sure the property returns just the date of ``Fact().start``."""
         assert fact.date == fact.start.date()
 
-    def test_serialized_name_with_category_and_description(self, fact):
-        """Make sure that the property returns a string matching our expectation."""
-        expectation = '{f.activity.name}@{f.category.name}, {f.description}'.format(f=fact)
-        assert fact.serialized_name == expectation
-
-    def test_serialized_name_with_category_no_description(self, fact):
-        """Make sure that the property returns a string matching our expectation."""
-        fact.description = None
-        expectation = '{f.activity.name}@{f.category.name}'.format(f=fact)
-        assert fact.serialized_name == expectation
-
-    def test_serialized_name_with_description_no_category(self, fact):
-        """Make sure that the property returns a string matching our expectation."""
-        fact.activity.category = None
-        expectation = '{f.activity.name}, {f.description}'.format(f=fact)
-        assert fact.serialized_name == expectation
-
     def test_category_property(self, fact):
         """Make sure the property returns this facts category."""
         assert fact.category == fact.activity.category
@@ -315,29 +298,31 @@ class TestFact(object):
         assert fact == other
 
     def test__str__(self, fact):
-        expectation = '{start} - {end} {serialized_name}'.format(
-            start=fact.start.strftime("%d-%m-%Y %H:%M"),
-            end=fact.end.strftime("%H:%M"),
-            serialized_name=fact.serialized_name)
+        expectation = '{start} to {end} {activity}@{category}, {description}'.format(
+            start=fact.start.strftime('%d-%m-%Y %H:%M'),
+            end=fact.end.strftime('%d-%m-%Y %H:%M'),
+            activity=fact.activity.name,
+            category=fact.category.name,
+            description=fact.description
+        )
         assert text(fact) == expectation
 
     def test__str__no_end(self, fact):
         fact.end = None
-        expectation = '{start} {serialized_name}'.format(
-            start=fact.start.strftime("%d-%m-%Y %H:%M"),
-            serialized_name=fact.serialized_name)
+        expectation = '{start} {activity}@{category}, {description}'.format(
+            start=fact.start.strftime('%d-%m-%Y %H:%M'),
+            activity=fact.activity.name,
+            category=fact.category.name,
+            description=fact.description
+        )
         assert text(fact) == expectation
 
-    def test__repr__(self, fact):
-        expectation = str('{start} - {end} {serialized_name}').format(
-            start=fact.start.strftime("%d-%m-%Y %H:%M"),
-            end=fact.end.strftime("%H:%M"),
-            serialized_name=repr(fact.serialized_name))
-        assert repr(fact) == expectation
-
-    def test__repr__no_end(self, fact):
+    def test__str__no_start_no_end(self, fact):
+        fact.start = None
         fact.end = None
-        expectation = str('{start} {serialized_name}').format(
-            start=fact.start.strftime("%d-%m-%Y %H:%M"),
-            serialized_name=repr(fact.serialized_name))
-        assert repr(fact) == expectation
+        expectation = '{activity}@{category}, {description}'.format(
+            activity=fact.activity.name,
+            category=fact.category.name,
+            description=fact.description
+        )
+        assert text(fact) == expectation


### PR DESCRIPTION
As ``Fact.serialized_name`` is not realy needed in our rewrite we remove
it from the ``Fact`` class. This however meant that we had to transfer
some of its string construction logic to ``Fact.__str__``.
In order to avoid duplicating the effort with regards to
``Fact.__repr__`` and because issue #131 will take care of it in a
holistic way anyway we removed ``Fact.__repr__`` for now ass well.
Tests have been adjusted accordingly.

Note:
* Our Fact class now provides a proper text representation even if it
misses any ``Fact.start`` value.
* This PR includes a minor refactoring commit as well as an additional test case. Both are added as seperate commits.

Closes: #146