### PR TITLE
Use factory.Faker only and wrap 'fauxfactory' (#149)

### DIFF
--- a/tests/backends/sqlalchemy/factories.py
+++ b/tests/backends/sqlalchemy/factories.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 import datetime
 
 import factory
-import faker
 from hamster_lib.backends.sqlalchemy.objects import (AlchemyActivity,
                                                     AlchemyCategory,
                                                     AlchemyFact)
@@ -50,8 +49,8 @@ class AlchemyFactFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     pk = factory.Sequence(lambda n: n)
     activity = factory.SubFactory(AlchemyActivityFactory)
-    start = faker.Faker().date_time()
-    end = start + datetime.timedelta(hours=3)
+    start = factory.Faker('date_time')
+    end = factory.LazyAttribute(lambda o: o.start + datetime.timedelta(hours=3))
     description = factory.Faker('paragraph')
     tags = []
 

--- a/tests/hamster_lib/factories.py
+++ b/tests/hamster_lib/factories.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 import datetime
 
 import factory
-import faker
 import fauxfactory
 from future.utils import python_2_unicode_compatible
 from hamster_lib import objects
@@ -18,7 +17,11 @@ class CategoryFactory(factory.Factory):
     """Factory providing randomized ``hamster_lib.Category`` instances."""
 
     pk = None
-    name = fauxfactory.gen_string('utf8')
+    # Although we do not need to reference to the object beeing created and
+    # ``LazyFunction`` seems sufficient it is not as we could not pass on the
+    # string encoding. ``LazyAttribute`` allows us to specify a lambda that
+    # circumvents this problem.
+    name = factory.LazyAttribute(lambda x: fauxfactory.gen_string('utf8'))
 
     class Meta:
         model = objects.Category
@@ -47,8 +50,8 @@ class FactFactory(factory.Factory):
 
     pk = None
     activity = factory.SubFactory(ActivityFactory)
-    start = faker.Faker().date_time()
-    end = start + datetime.timedelta(hours=3)
+    start = factory.Faker('date_time')
+    end = factory.LazyAttribute(lambda o: o.start + datetime.timedelta(hours=3))
     description = factory.Faker('paragraph')
 
     class Meta:


### PR DESCRIPTION
This removes the naive and error prone usage of stand alone ``faker``
calls in our factories for the proper ``factory.Faker`` ones. Those
basicly wrap our calls in ``LazyAttributes``. Where we generate random
data from non-faker sources, e.g. ``fauxfactory`` we make sure to do the
wrapping ourselfs.

Closes: #149