### PR TITLE
[137] Make objects hashable

### DIFF
--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -27,6 +27,8 @@ from collections import namedtuple
 from future.utils import python_2_unicode_compatible
 from six import text_type
 
+
+# Named tuples used  to 'serialize' our object instances.
 CategoryTuple = namedtuple('CategoryTuple', ('pk', 'name'))
 ActivityTuple = namedtuple('ActivityTuple', ('pk', 'name', 'category', 'deleted'))
 FactTuple = namedtuple('FactTuple', ('pk', 'activity', 'start', 'end', 'description', 'tags'))
@@ -242,12 +244,11 @@ class Activity(object):
 
 @python_2_unicode_compatible
 class Fact(object):
-    """Storage agnostic class for facts.
-
-    Note:
-        There is some weired black magic still to be integrated from
-        ``store.db.Storage``. Among it ``__get_facts()``.
-    """
+    """Storage agnostic class for facts."""
+    # [TODO]
+    # There is some weired black magic still to be integrated from
+    # ``store.db.Storage``. Among it ``__get_facts()``.
+    #
 
     def __init__(self, activity, start, end=None, pk=None, description=None, tags=None):
         """
@@ -607,7 +608,7 @@ class Fact(object):
 
     def as_tuple(self, include_pk=True):
         """
-        Provide a tuple representation of this facts relevant 'fields'.
+        Provide a tuple representation of this facts relevant attributes.
 
         Args:
             include_pk (bool): Whether to include the instances pk or not. Note that if

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -267,8 +267,8 @@ class Fact(object):
         self.end = end
         self.description = description
         if tags is None:
-            tags = []
-        self.tags = list(tags)
+            tags = set()
+        self.tags = set(tags)
 
     @classmethod
     def create_from_raw_fact(cls, raw_fact):

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -107,6 +107,10 @@ class Category(object):
             other = None
         return self.as_tuple() == other
 
+    def __hash__(self):
+        """Naive hashing method."""
+        return hash(self.as_tuple())
+
     def __str__(self):
         return '{name}'.format(name=self.name)
 
@@ -215,6 +219,10 @@ class Activity(object):
         if not isinstance(other, ActivityTuple):
             other = other.as_tuple()
         return self.as_tuple() == other
+
+    def __hash__(self):
+        """Naive hashing method."""
+        return hash(self.as_tuple())
 
     def __str__(self):
         if self.category is None:
@@ -613,7 +621,7 @@ class Fact(object):
             pk = False
         # [FIXME] Once tags are implemented, they need to be added here!
         return FactTuple(pk, self.activity.as_tuple(include_pk=include_pk), self.start,
-            self.end, self.description, [])
+            self.end, self.description, frozenset())
 
     def equal_fields(self, other):
         """
@@ -637,6 +645,10 @@ class Fact(object):
             other = other.as_tuple()
 
         return self.as_tuple() == other
+
+    def __hash__(self):
+        """Naive hashing method."""
+        return hash(self.as_tuple())
 
     def __str__(self):
         result = text_type(self.activity.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,4 +127,4 @@ def description_valid_parametrized(request):
 @pytest.fixture(params='alpha cyrillic latin1 utf8'.split())
 def tag_list_valid_parametrized(request):
     """Provide a variety of strings that should be valid *descriptions*."""
-    return [fauxfactory.gen_string(request.param) for i in range(4)]
+    return set([fauxfactory.gen_string(request.param) for i in range(4)])

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -60,6 +60,23 @@ class TestCategory(object):
         assert category is not other_category
         assert category == other_category
 
+    def test_is_hashable(self, category):
+        """Test that ``Category`` instances are hashable."""
+        assert hash(category)
+
+    def test_hash_method(self, category):
+        """Test that ``__hash__`` returns the hash expected."""
+        assert hash(category) == hash(category.as_tuple())
+
+    def test_hash_different_between_instances(self, category_factory):
+        """
+        Test that different instances have different hashes.
+
+        This is actually unneeded as we are merely testing the builtin ``hash``
+        function and ``Category.as_tuple`` but for reassurance we test it anyway.
+        """
+        assert hash(category_factory()) != hash(category_factory())
+
     def test__str__(self, category):
         """Test string representation."""
         assert '{name}'.format(name=category.name) == text(category)
@@ -132,6 +149,23 @@ class TestActivity(object):
         other = copy.deepcopy(activity)
         assert activity is not other
         assert activity == other
+
+    def test_is_hashable(self, activity):
+        """Test that ``Category`` instances are hashable."""
+        assert hash(activity)
+
+    def test_hash_method(self, activity):
+        """Test that ``__hash__`` returns the hash expected."""
+        assert hash(activity) == hash(activity.as_tuple())
+
+    def test_hash_different_between_instances(self, activity_factory):
+        """
+        Test that different instances have different hashes.
+
+        This is actually unneeded as we are merely testing the builtin ``hash``
+        function and ``Category.as_tuple`` but for reassurance we test it anyway.
+        """
+        assert hash(activity_factory()) != hash(activity_factory())
 
     def test__str__without_category(self, activity):
         activity.category = None
@@ -296,6 +330,23 @@ class TestFact(object):
         other = copy.deepcopy(fact)
         assert fact is not other
         assert fact == other
+
+    def test_is_hashable(self, fact):
+        """Test that ``Fact`` instances are hashable."""
+        assert hash(fact)
+
+    def test_hash_method(self, fact):
+        """Test that ``__hash__`` returns the hash expected."""
+        assert hash(fact) == hash(fact.as_tuple())
+
+    def test_hash_different_between_instances(self, fact_factory):
+        """
+        Test that different instances have different hashes.
+
+        This is actually unneeded as we are merely testing the builtin ``hash``
+        function and ``Fact.as_tuple`` but for reassurance we test it anyway.
+        """
+        assert hash(fact_factory()) != hash(fact_factory())
 
     def test__str__(self, fact):
         expectation = '{start} to {end} {activity}@{category}, {description}'.format(


### PR DESCRIPTION
This PR introduces a naive ``__hash__`` implementation for classes in ``hamster_lib.objects`` in order to make sure they are ``hashable``.

As a side effect we also include a commit that changes ``Fact.tags`` to a ``set`` (from being a ``list`` before). Although tags have not actually been implemented it seems semantically more correct.

Closes: #137  