### PR TITLE
[131] Add consistent __repr__ methods

### DIFF
--- a/hamster_lib/helpers.py
+++ b/hamster_lib/helpers.py
@@ -2,9 +2,9 @@
 
 # Copyright (C) 2015-2016 Eric Goller <eric.goller@ninjaduck.solutions>
 
-# This file is part of 'hamste-lib'.
+# This file is part of 'hamster-lib'.
 #
-# 'hamster_lib' is free software: you can redistribute it and/or modify
+# 'hamster-lib' is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -114,9 +114,10 @@ class Category(object):
         return hash(self.as_tuple())
 
     def __str__(self):
-        return '{name}'.format(name=self.name)
+        return text_type('{name}'.format(name=self.name))
 
     def __repr__(self):
+        """Return an instance representation containing additional information."""
         return str('[{pk}] {name}'.format(pk=repr(self.pk), name=repr(self.name)))
 
 
@@ -230,16 +231,18 @@ class Activity(object):
         if self.category is None:
             string = '{name}'.format(name=self.name)
         else:
-            string = '{name} ({category})'.format(name=self.name, category=self.category.name)
-        return string
+            string = '{name} ({category})'.format(
+                name=self.name, category=self.category.name)
+        return text_type(string)
 
     def __repr__(self):
+        """Return an instance representation containing additional information."""
         if self.category is None:
-            string = str('[{pk}] {name}').format(pk=repr(self.pk), name=repr(self.name))
+            string = '[{pk}] {name}'.format(pk=repr(self.pk), name=repr(self.name))
         else:
-            string = str('[{pk}] {name} ({category})').format(
+            string = '[{pk}] {name} ({category})'.format(
                 pk=repr(self.pk), name=repr(self.name), category=repr(self.category.name))
-        return string
+        return str(string)
 
 
 @python_2_unicode_compatible
@@ -665,14 +668,40 @@ class Fact(object):
             #                    self.description or "")
 
         if self.start:
-            start = text_type(self.start.strftime("%d-%m-%Y %H:%M"))
+            start = self.start.strftime("%d-%m-%Y %H:%M")
 
         if self.end:
-            end = text_type(self.end.strftime("%d-%m-%Y %H:%M"))
+            end = self.end.strftime("%d-%m-%Y %H:%M")
 
         if self.start and self.end:
             result = '{} to {} {}'.format(start, end, result)
         elif self.start and not self.end:
             result = '{} {}'.format(start, result)
 
-        return result
+        return text_type(result)
+
+    def __repr__(self):
+        result = repr(self.activity.name)
+
+        if self.category:
+            result += "@%s" % repr(self.category.name)
+
+        if self.description or self.tags:
+            # [FIXME]
+            # Workaround until we address tags!
+            result += ', {}'.format(repr(self.description) or '')
+            # result += "%s, %s" % (" ".join(["#%s" % tag for tag in self.tags]),
+            #                    self.description or "")
+
+        if self.start:
+            start = repr(self.start.strftime("%d-%m-%Y %H:%M"))
+
+        if self.end:
+            end = repr(self.end.strftime("%d-%m-%Y %H:%M"))
+
+        if self.start and self.end:
+            result = '{} to {} {}'.format(start, end, result)
+        elif self.start and not self.end:
+            result = '{} {}'.format(start, result)
+
+        return str(result)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup
 
@@ -30,13 +30,7 @@ setup(
     author="Eric Goller",
     author_email='eric.goller@ninjaduck.solutions',
     url='https://github.com/projecthamster/hamster-lib',
-    packages=[
-        'hamster_lib',
-        'hamster_lib.backends',
-        'hamster_lib.backends.sqlalchemy',
-    ],
-    package_dir={'hamster_lib':
-                 'hamster_lib'},
+    packages=find_packages(),
     install_requires=requirements,
     license="GPL3",
     zip_safe=False,

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -112,8 +112,7 @@ class TestCategoryManager():
 
     def test_update_without_pk(self, alchemy_store, alchemy_category_factory):
         """Make sure that passing a category without a PK raises an error."""
-        category = alchemy_category_factory().as_hamster()
-        category.pk = None
+        category = alchemy_category_factory.build(pk=None).as_hamster()
         with pytest.raises(ValueError):
             alchemy_store.categories._update(category)
 
@@ -141,9 +140,14 @@ class TestCategoryManager():
 
     def test_remove_no_pk(self, alchemy_store, alchemy_category_factory):
         """Ensure that passing a alchemy_category without an PK raises an error."""
-        category = alchemy_category_factory.build().as_hamster()
-        category.pk = None
+        category = alchemy_category_factory.build(pk=None).as_hamster()
         with pytest.raises(ValueError):
+            alchemy_store.categories.remove(category)
+
+    def test_remove_invalid_pk(self, alchemy_store, alchemy_category_factory):
+        """Ensure that passing a alchemy_category without an PK raises an error."""
+        category = alchemy_category_factory.build(pk=800).as_hamster()
+        with pytest.raises(KeyError):
             alchemy_store.categories.remove(category)
 
     def test_get_existing_pk(self, alchemy_store, alchemy_category_factory):

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -82,9 +82,12 @@ class TestCategory(object):
         assert '{name}'.format(name=category.name) == text(category)
 
     def test__repr__(self, category):
-        """Test debug representation."""
-        assert str('[{pk}] {name}').format(
-            pk=repr(category.pk), name=repr(category.name)) == repr(category)
+        """Test representation method."""
+        result = repr(category)
+        assert isinstance(result, str)
+        expectation = '[{pk}] {name}'.format(pk=repr(category.pk),
+            name=repr(category.name))
+        assert result == expectation
 
 
 class TestActivity(object):
@@ -177,14 +180,19 @@ class TestActivity(object):
 
     def test__repr__with_category(self, activity):
         """Make sure our debugging representation matches our expectations."""
-        assert repr(activity) == str('[{pk}] {name} ({category})').format(
+        result = repr(activity)
+        assert isinstance(result, str)
+        expectation = '[{pk}] {name} ({category})'.format(
             pk=repr(activity.pk), name=repr(activity.name), category=repr(activity.category.name))
+        assert result == expectation
 
     def test__repr__without_category(self, activity):
         """Make sure our debugging representation matches our expectations."""
         activity.category = None
-        assert repr(activity) == str('[{pk}] {name}').format(pk=repr(activity.pk),
-            name=repr(activity.name))
+        result = repr(activity)
+        assert isinstance(result, str)
+        expectation = '[{pk}] {name}'.format(pk=repr(activity.pk), name=repr(activity.name))
+        assert result == expectation
 
 
 class TestFact(object):
@@ -377,3 +385,44 @@ class TestFact(object):
             description=fact.description
         )
         assert text(fact) == expectation
+
+    def test__repr__(self, fact):
+        """Make sure our debugging representation matches our expectations."""
+        expectation = '{start} to {end} {activity}@{category}, {description}'.format(
+            start=repr(fact.start.strftime('%d-%m-%Y %H:%M')),
+            end=repr(fact.end.strftime('%d-%m-%Y %H:%M')),
+            activity=repr(fact.activity.name),
+            category=repr(fact.category.name),
+            description=repr(fact.description)
+        )
+        result = repr(fact)
+        assert isinstance(result, str)
+        assert result == expectation
+
+    def test__repr__no_end(self, fact):
+        """Test that facts without end datetime are represented properly."""
+        result = repr(fact)
+        assert isinstance(result, str)
+        fact.end = None
+        expectation = '{start} {activity}@{category}, {description}'.format(
+            start=repr(fact.start.strftime('%d-%m-%Y %H:%M')),
+            activity=repr(fact.activity.name),
+            category=repr(fact.category.name),
+            description=repr(fact.description)
+        )
+        result = repr(fact)
+        assert isinstance(result, str)
+        assert result == expectation
+
+    def test__repr__no_start_no_end(self, fact):
+        """Test that facts without timeinfo are represented properly."""
+        fact.start = None
+        fact.end = None
+        expectation = '{activity}@{category}, {description}'.format(
+            activity=repr(fact.activity.name),
+            category=repr(fact.category.name),
+            description=repr(fact.description)
+        )
+        result = repr(fact)
+        assert isinstance(result, str)
+        assert result == expectation


### PR DESCRIPTION
This pr adds dedicated and refactored ``__repr__`` methods to our ``hamsterlib.objects`` classes.
Those make sure that instances can be represented even in non unicode environments.

Closes: #131 