### PR TITLE
[#130]Add test and fix for SA Engine repr failure

### DIFF
--- a/hamster_lib/backends/sqlalchemy/storage.py
+++ b/hamster_lib/backends/sqlalchemy/storage.py
@@ -81,7 +81,7 @@ class SQLAlchemyStore(storage.BaseStore):
         # we receive a session. Should be require the session to bring its own
         # engine?
         engine = create_engine(self._get_db_url())
-        self.logger.debug(_("Engine '{}' created.".format(engine)))
+        self.logger.debug(_('Engine created.'))
         objects.metadata.bind = engine
         objects.metadata.create_all(engine)
         self.logger.debug(_("Database tables created."))

--- a/hamster_lib/lib.py
+++ b/hamster_lib/lib.py
@@ -36,8 +36,11 @@ REGISTERED_BACKENDS = {
 }
 
 # See: https://wiki.python.org/moin/PortingToPy3k/BilingualQuickRef#gettext
+# [FIXME]
+# Is this correct? http://www.wefearchange.org/2012/06/the-right-way-to-internationalize-your.html
+# seems to user ``sys.version_info.major > 3``
 kwargs = {}
-if sys.version_info < (3,):
+if sys.version_info.major < 3:
     kwargs['unicode'] = True
 gettext.install('hamster-lib', **kwargs)
 

--- a/tests/backends/sqlalchemy/conftest.py
+++ b/tests/backends/sqlalchemy/conftest.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import os
 
 import fauxfactory
 import pytest
@@ -49,6 +50,20 @@ def alchemy_runner(request):
         common.Session.remove()
 
     request.addfinalizer(fin)
+
+
+@pytest.fixture(params=[
+    fauxfactory.gen_utf8(),
+    fauxfactory.gen_alphanumeric(),
+    ':memory:',
+])
+def db_path_parametrized(request, tmpdir):
+    """Parametrized database paths."""
+    if request.param == ':memory:':
+        path = request.param
+    else:
+        path = os.path.join(tmpdir.strpath, request.param)
+    return path
 
 
 @pytest.fixture

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -6,12 +6,13 @@ import datetime
 
 import pytest
 from hamster_lib.backends.sqlalchemy import (AlchemyActivity, AlchemyCategory,
-                                            AlchemyFact)
+                                            AlchemyFact, SQLAlchemyStore)
 
 
 # The reason we see a great deal of count == 0 statements is to make sure that
 # db rollback works as expected. Once we are confident in our sqlalchemy/pytest
 # setup those are not really needed.
+
 
 class TestStore(object):
     """Tests to make sure our store/test setup behaves as expected."""
@@ -60,6 +61,11 @@ class TestStore(object):
         alchemy_store.config = alchemy_config_missing_store_config_parametrized
         with pytest.raises(ValueError):
             alchemy_store._get_db_url()
+
+    def test_init_with_unicode_path(self, alchemy_config, db_path_parametrized):
+        """Test that Instantiating a store with a unicode path works."""
+        alchemy_config['db_path'] = db_path_parametrized
+        assert SQLAlchemyStore(alchemy_config)
 
 
 class TestCategoryManager():


### PR DESCRIPTION
Running python 2, it apears SQLAlchemy is not fully capable to handle
unicode strings as urls. While they can be passed and will be processed
(correctly as far as we can tell) there are issues with 'representing'
an ``Engine`` or ``sqlalchemy.engine.url.URL``. As far as we understand,
their ``repr()`` call will naivly construct a ``str`` from its various
components. If any of those substrings (like the URL) happens to be an
unicode string, this will fail if it can not be ascii-decoded.
SQLAlchemy should propably call repr(url) instead.

For now, this commit just avoids the problem entirely by amending the
triggering log message not to render a string representation of the
created engine. A proper solution would probably be to write a custom
wrapper function that handles Engine representation properly.

Also, a test that triggers the origianl offending behaviour has been
added, so any regression should be easier to find.

Closes: #130