### PR TITLE
Refactor ``FactManager._get_all()`` and ``_timeframe_is_free()``

### DIFF
--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -609,7 +609,7 @@ class BaseFactManager(BaseManager):
 
         return self._get_all(start, end, filter_term)
 
-    def _get_all(self, start=None, end=None, search_terms=''):
+    def _get_all(self, start=None, end=None, search_terms='', partial=False):
         """
         Return a list of ``Facts`` matching given criteria.
 
@@ -618,8 +618,10 @@ class BaseFactManager(BaseManager):
                 this datetime. Defaults to ``None``.
             end_date (datetime.datetime): Consider only Facts ending before or at
                 this datetime. Defaults to ``None``.
-            filter_term (str, optional): Only consider ``Facts`` with this string as part of their
-                associated ``Activity.name``.
+            search_term (text_type): Cases insensitive strings to match
+                ``Activity.name`` or ``Category.name``.
+            partial (bool): If ``False`` only facts which start *and* end
+                within the timeframe will be considered.
 
         Returns:
             list: List of ``Facts`` matching given specifications.
@@ -647,19 +649,6 @@ class BaseFactManager(BaseManager):
             datetime.datetime.combine(today, self.store.config['day_start']),
             helpers.end_day_to_datetime(today, self.store.config)
         )
-
-    def _timeframe_is_free(self, start, end):
-        """
-        Determine if a given timeframe already holds any facts start or end time.
-
-        Args:
-            start (datetime): *Start*-datetime that needs to be validated.
-            end (datetime): *End*-datetime that needs to be validated.
-
-        Returns:
-            bool: True if free, False if occupied.
-        """
-        raise NotImplementedError
 
     def _start_tmp_fact(self, fact):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@ tag = False
 branch = True
 source = hamster_lib
 
+[coverage:report]
+precision = 2
+
 [isort]
 not_skip = __init__.py
 known_third_party = faker,factory, faker, freezegun, future, hamster_lib, icalendar, past, pytest, pytest_factoryboy,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,16 @@ def start_end_datetimes_from_offset():
     return generate
 
 
+@pytest.fixture(params=(True, False))
+def bool_value_parametrized(request):
+    """
+    Return a parametrized boolean value.
+
+    This is usefull to easily parametrize tests using flags.
+    """
+    return request.param
+
+
 # Attribute fixtures (non-parametrized)
 @pytest.fixture
 def name():


### PR DESCRIPTION
This commit removes ``FactManager._timeframe_is_free``. It's only
difference to ``FactManager._get_all()`` was that it would consider
facts that are only partially within the given timeframe. This behavior
has been incorporated into ``_get_all()`` instead. By passing
``partial=True`` as a ``kwarg`` is the method will return all facts
within the timeframe that either start or end in it.
This can then be used to not only check if a timeframe is free but (in
case of an ``_update`` if the only fact blocking it is the one to be
updated.

We also used the opportunity to provide more and better tests.

Closes: #138