### PR TITLE
Improve ActivityManager.get_all() (#134)

### DIFF
--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -395,13 +395,14 @@ class BaseActivityManager(BaseManager):
 
         raise NotImplementedError
 
-    def get_all(self, category=None, search_term=''):
+    def get_all(self, category=False, search_term=''):
         """
         Return all matching activities.
 
         Args:
             category (hamster_lib.Category, optional): Limit activities to this category.
-                Defaults to ``None``.
+                Defaults to ``False``. If ``category=None`` only activities without a
+                category will be considered.
             search_term (str, optional): Limit activities to those matching this string
                 a substring in their name. Defaults to ``empty string``.
 
@@ -421,10 +422,6 @@ class BaseActivityManager(BaseManager):
         # ``__get_category_activivty`` order by lower(activity.name),
         # ``__get_activities```orders by most recent start date *and*
         # lower(activity.name).
-
-        # [FIXME]
-        # We need a way to distinguish between ``activity.category = None`` and
-        # "list all activities".
         raise NotImplementedError
 
 

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -416,13 +416,16 @@ class TestActivityManager():
             alchemy_store.activities.get_by_composite(invalid_name, activity.category)
 
     def test_get_all_without_category(self, alchemy_store, alchemy_activity):
-        """
-        Note:
-            This method is not meant to return 'all-activities' but rather
-            all of a certain alchemy_category.
-        """
+        """Make sure method returns all activities."""
         result = alchemy_store.activities.get_all()
-        assert len(result) == 0
+        assert len(result) == 1
+
+    def test_get_all_with_category_none(self, alchemy_store, alchemy_activity,
+            alchemy_activity_factory):
+        """Make sure only activities without a category are areturned."""
+        activity = alchemy_activity_factory(category=None)
+        result = alchemy_store.activities.get_all(category=activity.category)
+        assert len(result) == 1
 
     def test_get_all_with_category(self, alchemy_store, alchemy_activity):
         """Make sure that activities matching the given alchemy_category are returned."""


### PR DESCRIPTION
This commit refactors the manager method in order to allow it to
retrieve *all* stored activities. Previously ``categories=None``
translated to fetching all uncategorized categories. We now added the
option to pass ``categories=False`` in order to fetch all activities.

Closes: #134