### PR TITLE
Add styleguide (#76)

### DIFF
--- a/docs/labels.rst
+++ b/docs/labels.rst
@@ -1,0 +1,127 @@
+Labels and Milestones
+======================
+Each issue should have at least one label from the Type and Status
+section assigned.
+
+Type (#cc317c)
+------
+Enhancement
+   Issues that introduce new functionality. Original post should include the
+   following information:
+
+   * Description of desired functionality
+   * A (prosaic) description of a use case
+   * Optionally add suggestions/ideas about how to implement the feature. As
+     always, PRs are welcome. :)
+
+Bug
+   Issues about something not working as intended. Original post should include
+   the following information:
+
+   * Platform (operating system, architecture)
+   * Version of package in question
+   * Steps suitable to reproduce the problem
+   * Error message/console output
+   * If you are willing to share: log files
+
+   In case of an error within the documentation the above requirements can be
+   omitted.
+
+Duplicate
+   Indicates that the issues topic has been addressed before and
+   all discussion/comments should happen in the referenced issue instead.
+
+Question
+   Indicates that the issue is less about actual code/functionality but
+   addresses a general (design) question that needs to be decided upon before
+   an implementation can be considered.
+
+Story
+   Used to track multiple related issues.
+
+Topic (#fbca04)
+-------
+Issues without a specific topic assigned deal with general functionality.
+The main purpose if these labels is to allow contributors with specific
+skill sets to find issues fitting them.
+
+UX
+   Issue does not deal with functionality itself but with user interaction.
+
+UI
+   Issue deal with visual representation of functionality.
+
+Documentation
+   Issue does not require actual coding or even necessarily python
+   knowledge at all but deals with documenting the project itself. It may be
+   used to indicate improvements to the code's documentation, in which case a
+   basic familiarity with the language and code layout is highly desirable.
+   However, it may also be used for issues dealing with front end user facing
+   documentation that elaborates on how to use the package in a plain natural
+   language.
+
+Packaging
+   Issues related to project package releases.
+
+Meta
+   Issues related to the general project setup.
+
+
+Status (#159818)
+-------
+Labels that indicate the status of an issue. Their provide a quick and easy
+answer to whether the issue is actionable or not.
+
+Decision needed
+   Tickets that need a design decision are blocked for development until a
+   project leader clarifies the way in which the issue should be approached.
+  
+Information needed
+   This label indicates that the issue has not enough information in order to
+   decide on how to go forward. See the documentation about our triage process
+   for more information.
+
+Help needed
+   Designates issues which seem to require a certain skill currently not
+   available to the core developers. Such issues are unlikely to be solved
+   unless a contributor with the required skill-set steps forward to help out.
+   Giving pointers to domain specific resources or best practices may already
+   be enough. This does not necessarily imply that all the actual coding has to
+   be done by the person providing the desired skill.
+
+Ready
+   The issue has been screened by the core devs and may be worked upon at your
+   leisure.
+
+Blocked
+  This issue can only be addressed once another issue has been resolved. The
+  cause may be an internal issue or external dependency.
+
+In progress:
+   Issues currently worked on. If you want to join work on it please coordinate
+   with its assignee to achieve the best possible solution and avoid duplicate
+   work.
+
+Rejected:
+   Issues that are not considered within the general goals of the project.
+   A reference to said previous discussion/issue should be given.
+
+Other
+---------------
+Labels that did not warrant their own group.
+
+Ready for review
+    Pull Requests that are considered complete. A review by at least one core
+    developer is required prior to merging it.
+
+Good First Bug
+   This label marks tickets that are easy to get started with. The ticket 
+   should be ideal for beginners to dive into the code base, indicating
+   `low-hanging fruits <http://www.urbandictionary.com/define.php?term=low-hanging%20fruit>`_.
+    These tickets generally should fit the following requirements:
+   * No comprehensive knowledge of the entire code base needed.
+   * No particular 3rd party library familiarity required.
+   * Most likely does not involve long term effort.
+   * No elaborate design decisions involved.
+
+

--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -1,0 +1,128 @@
+General
+=======
+
+.. class:: compact
+
+* Follow `PEP 8 <http://www.python.org/dev/peps/pep-0008/>`_ and
+  `PEP 257 <https://www.python.org/dev/peps/pep-0257/>`_.  
+* Try to stick to 79 chars. When this is not enough you may use up to 99 chars.
+  This is more tolerable for code than for documentation.
+* Use double quotes for human readable strings and single quotes for all other strings.
+* Private functions and methods are prefixed with a single underscore: ``_method``.
+
+Python 2 and 3 compability
+---------------------------
+
+.. class:: compact
+
+* Declare encoding in first line: ``-*- encoding: utf-8 -*-``
+* Use *absolute_import* and *unicode_literals* from the ``__future__`` package.
+* Use *six.text_type* to cast a unicode string under python 2 and 3.
+
+Code-style
+--------------
+* Readability trumps almost anything. Readable and approachable code carries
+  it's weight as a lower contribution-barrier, less bugs and easier
+  debugging.  Having a particular clever, aka dense, alternative is rarely
+  warranted.
+* Favour multiple small specialized (local) functions/methods over big
+  all-encompassing ones.
+* Use well established and maintained high quality 3rd party libraries over own
+  implementations.
+* Use expressive variable names. If you have to trade off verbosity and 
+  expressiveness, go for the later.
+* Assigning variables even if they are used only once can be preferable if
+  expressions become clearer and less dense.
+* Any method / function that is not deliberately considered part of the public
+  API should be considered private. This is to increase the mental threshold
+  for declaring them public as well as making it easier to the occasional
+  reader to figure out which parts of the code are relevant to his/her needs
+  and which are internal details.
+* Try to minimize use of return statements with a method/function while using
+  exceptions wherever suitable.  While this may not allways improve readability
+  it tends to make debugging easier as it provides one central breaking point.
+* Methods should have the following order: special (``__foo__``) > public  >
+  private (`_foo``). 
+
+Imports
+-------
+
+.. class:: compact
+
+* Imports should be grouped in the following order:
+
+    * standard library imports
+    * related third party imports
+    * local application/library specific imports
+
+* You should put a blank line between each group of imports.
+* Always order each group of imports by name.
+* You can use `isort <https://github.com/timothycrosley/isort>`_ to sort the
+  imports.
+* Remove import statements that are no longer used when you change code.
+
+Documentation
+---------------
+
+.. class:: compact
+
+* Docstrings should be provided for all public and private classes, methods and
+  functions. Simple local functions may go without. They should elaborate the
+  methods signature and use.
+* Use `google-style <http://www.sphinx-doc.org/en/stable/ext/example_google.html#example-google>`_
+  docstrings. Sphinx's `napoleon <http://www.sphinx-doc.org/en/stable/ext/napoleon.html#module-sphinx.ext.napoleon>`_
+  extension will make turn this into valid ``rst``.
+* use block comments to explain implementation 
+
+Committing and commit messages
+------------------------------
+
+.. class:: compact
+
+* Commit one change/feature at a time (you can use `tig <http://jonas.nitro.dk/tig/>`_
+  to select the changes you want to commit).
+* Separate bug fixes from feature changes, bugfixes may need to be backported
+  to the stable branch.
+* Maximum line length is 50 characters for the first line and 72 for all
+  following lines.
+* The first line is a short summary, no trailing period.
+* Leave a blank line between the summary and the body of the commit message.
+* Explain what you did and add all relevant information to the commit message.
+* If an issue exists for your feature/bug/task add it to the end of the commit
+  message.
+* Run the test suite **before** pushing your changes.
+* **Never commit** passwords, ``*.pyc`` files, sqlite database files or ``pdb`` calls.
+
+Rebasing
+--------
+
+.. class:: compact
+
+* try to rebase to keep the commit history linear:
+
+::
+
+    $ git pull --rebase
+
+* If you have uncommitted changes in your working directory use ``git stash`` to stash the changes while rebasing:
+
+::
+
+    $ git stash
+    $ git pull --rebase
+    $ git stash pop
+
+* **Do not** rebase already published changesets!
+
+Pull Requests
+-------------
+
+.. class:: compact
+
+The title of a pull request should contain a summary of the issue it is related
+to, as well as the issue id. An example would look like
+``Advanced report options (#23)``. This way, a link between the PR and the
+issue will be created.
+
+Every pull request has to be approved by at least one other developer before
+merging.


### PR DESCRIPTION
This commits provides a first go at a basic styleguide for the project. This will most likly require more work in order to provide a clearer structure. As a seperate page we provide an overview over all labels used by the project.

Closes: #76 