### PR TITLE
Add ``rst`` specific settings to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,13 @@ end_of_line = lf
 indent_style = tab
 end_of_line = crlf
 
+[*.rst]
+indent_style = space
+indent_size = 3
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
 [LICENSE]
 insert_final_newline = false
 


### PR DESCRIPTION
In particular, this PR makes sure that we use a indentation of ``3``.