### PR TITLE
Add doc testenv to tox defaults and travis (#165)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - TOXENV=flake8
   - TOXENV=pep257
   - TOXENV=isort
+  - TOXENV=docs
+
 
 before_install:
   - pip install codecov

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -115,8 +115,8 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7 and 3.4. Check
-   https://codeship.com/projectchamster/hamster-lib/pull_requests
+3. The pull request should work for Python 2.7 and 3.4. Check `Travis
+   <https://travis-ci.org/projecthamster/hamster-lib/builds/142418469>`_
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/README.rst
+++ b/README.rst
@@ -22,15 +22,16 @@ A library for common timetracking functionality.
 
 ``hamster-lib`` aims to be a replacement for ``projecthamster``  backend
 library.  While we are not able to function as a  straight forward drop-in
-replacement we try very hard to stay as compatible as possible. As a consequence
-clients are able to switch to ``hamster-lib``  merely by changing some basic
-calls. Most of the semantics and return values will be as before.
+replacement we try very hard to stay as compatible as possible. As a
+consequence clients are able to switch to ``hamster-lib``  merely by changing
+some basic calls. Most of the semantics and return values will be as before.
 
-This itself points to a major architectural shift in the way ``hamster-lib`` approaches
-timetracking. We are firm believers in *do one thing, and do it well*. The tried and
-tested unix toolbox principle. As such we focus on providing useful backend
-functionality and helper methods so clients (dbus interfaces, CLIs or graphical UIs)
-can build upon a solid and consistent base and focus on their specific requirements.
+This itself points to a major architectural shift in the way ``hamster-lib``
+approaches timetracking. We are firm believers in *do one thing, and do it
+well*. The tried and tested unix toolbox principle. As such we focus on
+providing useful backend functionality and helper methods so clients (dbus
+interfaces, CLIs or graphical UIs) can build upon a solid and consistent base
+and focus on their specific requirements.
 
 Features
 --------
@@ -52,24 +53,24 @@ First Steps
 
 Additional Resources
 --------------------
-* `Documentation by 'read the docs' <https://hamster-lib.docs.projecthamster.org>`_
+* `Documentation by 'read the docs' <http://hamster-lib.docs.projecthamster.org/en/latest>`_
 * `CI thanks to Travis-CI <https://travis-ci.org/projecthamster/hamster-lib>`_
-* `Coverage reports by 'codecov' <https://codecov.io/projecthamster/hamster-lib>`_
+* `Coverage reports by 'codecov' <https://codecov.io/gh/projecthamster/hamster-lib>`_
 * `Dependency monitoring by 'requires.io' <https://requires.io/github/projecthamster/hamster-lib/requirements/?branch=master>`_
 
 News: Version 0.10.0
 ---------------------
-This new release marks our switch to semantic versioning and brings a few stability improvements
-as well as ``ìcal`` and ``xml`` export. We improved documentation, internal code and
-project handling a bit but for a full list of changes please refer to the changelog.
+This new release marks our switch to semantic versioning and brings a few
+stability improvements as well as ``ìcal`` and ``xml`` export. We improved
+documentation, internal code and project handling a bit but for a full list of
+changes please refer to the changelog.
 
 Todo
 ----
-This early release is mainly meant as a rough proof-of-concept at this stage. It
-showcases our API as well as our general design decisions.
-As such there are a few functionalities/details of the original ``projecthamster``
-backend that we wish to allow for, but are not provided so far.
-These are:
+This early release is mainly meant as a rough proof-of-concept at this stage.
+It showcases our API as well as our general design decisions.  As such there
+are a few functionalities/details of the original ``projecthamster`` backend
+that we wish to allow for, but are not provided so far.  These are:
 
 * Tags (We accept them but they are not stored in the backend.)
 * Autocomplete related methods
@@ -78,12 +79,12 @@ These are:
 
 Incompatibilities
 ------------------
-Despite our efforts to stay backwards compatible we did deliberately break the way
-``Facts`` without end dates are handled. We think allowing for them in any persistent
-backend creates a data consistency nightmare and so far there seems no conceivable
-use case for it, let alone an obvious semantic.
-What we do allow for is *one* ``ongoing fact``. That is a fact that has a start,
-but no end date. For details, please refer to the documentation.
+Despite our efforts to stay backwards compatible we did deliberately break the
+way ``Facts`` without end dates are handled. We think allowing for them in any
+persistent backend creates a data consistency nightmare and so far there seems
+no conceivable use case for it, let alone an obvious semantic.  What we do
+allow for is *one* ``ongoing fact``. That is a fact that has a start, but no
+end date. For details, please refer to the documentation.
 
 Credits
 ---------
@@ -91,5 +92,6 @@ Tools used in rendering this package:
 
 *  Cookiecutter_
 *  `cookiecutter-pypackage`_
+
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,6 @@
 hamsterlib
 ===============================
 
-.. image:: https://img.shields.io/pypi/v/hamster-lib.svg
-        :target: https://pypi.python.org/pypi/hamster-lib
-
 .. image:: https://img.shields.io/travis/projecthamster/hamster-lib/master.svg
         :target: https://travis-ci.org/projecthamster/hamster_lib
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,9 @@ extensions = [
     'alabaster',
 ]
 
+# Prevent non local immage warnings from showing
+suppress_warnings = ['image.nonlocal_uri']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -174,7 +177,7 @@ html_theme_path = [alabaster.get_path()]
 # here, relative to this directory. They are copied after the builtin
 # static files, so a file named "default.css" will overwrite the builtin
 # "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,8 @@ Contents:
    contributing
    packaging
    API reference <modules>
+   labels
+   styleguide
    notes
    authors
    history

--- a/docs/labels.rst
+++ b/docs/labels.rst
@@ -4,7 +4,7 @@ Each issue should have at least one label from the Type and Status
 section assigned.
 
 Type (#cc317c)
-------
+---------------
 Enhancement
    Issues that introduce new functionality. Original post should include the
    following information:
@@ -40,7 +40,7 @@ Story
    Used to track multiple related issues.
 
 Topic (#fbca04)
--------
+------------------
 Issues without a specific topic assigned deal with general functionality.
 The main purpose if these labels is to allow contributors with specific
 skill sets to find issues fitting them.
@@ -68,14 +68,14 @@ Meta
 
 
 Status (#159818)
--------
+-----------------
 Labels that indicate the status of an issue. Their provide a quick and easy
 answer to whether the issue is actionable or not.
 
 Decision needed
    Tickets that need a design decision are blocked for development until a
    project leader clarifies the way in which the issue should be approached.
-  
+
 Information needed
    This label indicates that the issue has not enough information in order to
    decide on how to go forward. See the documentation about our triage process
@@ -115,10 +115,11 @@ Ready for review
     developer is required prior to merging it.
 
 Good First Bug
-   This label marks tickets that are easy to get started with. The ticket 
+   This label marks tickets that are easy to get started with. The ticket
    should be ideal for beginners to dive into the code base, indicating
    `low-hanging fruits <http://www.urbandictionary.com/define.php?term=low-hanging%20fruit>`_.
-    These tickets generally should fit the following requirements:
+   These tickets generally should fit the following requirements:
+
    * No comprehensive knowledge of the entire code base needed.
    * No particular 3rd party library familiarity required.
    * Most likely does not involve long term effort.

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -1,12 +1,14 @@
 Notes
 =====
 
-These notes are just a dumping ground for semanitic information extracted from legacy hamster
-while dealing with its codebase that is not documented/obvious. Also, some basic
-troubleshooting heuristics and 'lessons learned' may be documented here for now.
+These notes are just a dumping ground for semanitic information extracted from
+legacy hamster while dealing with its codebase that is not documented/obvious.
+Also, some basic troubleshooting heuristics and 'lessons learned' may be
+documented here for now.
 
-* Why all this buisiness with ``search_names``, which are lowercase versions of proper names?
-  Is it because cases insesitive matching was not available? or due to performence considerations?
+* Why all this buisiness with ``search_names``, which are lowercase versions of
+  proper names?  Is it because cases insesitive matching was not available? or
+  due to performence considerations?
 
 * It looks like the dbus client assume PKs to be > 0 and uses 0 as marker for failure.
   Would be great if we can change that on the frontend instead of working around that.
@@ -27,7 +29,8 @@ troubleshooting heuristics and 'lessons learned' may be documented here for now.
         [SQL: 'INSERT INTO categories (id, name) VALUES (?, ?)'] [parameters: ((19, 'vero'),
         (20, 'officiis'), (21, 'aliquid'), (22, 'vero'), (23, 'dolorum'))]
 
-  after we started using factory-instance fixtures 'alchemy_category' vs 'alchemy_category_factory'
+  after we started using factory-instance fixtures 'alchemy_category' vs
+  'alchemy_category_factory'
 
 
 * Integrity Error (SQLAlchemy)
@@ -60,27 +63,34 @@ Opted against:
 
 Legacy Storage API notes
 ------------------------
-* ``get_tag_ids`` seems to create tags that have been passed if they do not exist
-* activities flagged as ``temporary`` dont get ressurected (``__add_fact``).
-* seperate ``storage.__get_activities`` is dedicated to autocomplete. we summerized its usecase
-  under the regular one so far.
-  The difference seems to be that autocomplete reasonable needs a way to retrieve *all*
-  activity names, irrespective of category association. This should be coverable by
-  adding a ``categories=False`` flag to our default method. Worth noting: considers only
-  non-deleted activities. Activities are returned ordered by their corresponding facts start time
-  with the 'latests' beeing first. Maybe it is actually cleaner to add a dedicated
-  method like this once we get to autocomplete.
+* ``get_tag_ids`` seems to create tags that have been passed if they do not
+  exist * activities flagged as ``temporary`` dont get ressurected
+  (``__add_fact``).
+* seperate ``storage.__get_activities`` is dedicated to autocomplete. we
+  summerized its usecase under the regular one so far.  The difference seems to
+  be that autocomplete reasonable needs a way to retrieve *all* activity names,
+  irrespective of category association. This should be coverable by adding a
+  ``categories=False`` flag to our default method. Worth noting: considers only
+  non-deleted activities. Activities are returned ordered by their
+  corresponding facts start time with the 'latests' beeing first. Maybe it is
+  actually cleaner to add a dedicated method like this once we get to
+  autocomplete.
 
 Dismissed:
-* resurrect/temporary for ``add_fact`` is about checking for preexisting activities
-  by using ``__get_activity_by_name``. If True we will consider 'deleted' activities
-  and stick this to our new fact.
+
+* resurrect/temporary for ``add_fact`` is about checking for preexisting
+  activities by using ``__get_activity_by_name``. If True we will consider
+  'deleted' activities and stick this to our new fact.
+
   * We don't do temporary facts.
 
-* if an activity is created with ``temporary=True`` it will be marked as ``deleted=True``.
-  why not set the attribute directly? Whats the role of a temporary activity?
-  * This is only used when creating *temporary facts* in order to prevent proper activities
-    beeing created for them. We don't do temporary facts, so we can ommit this.
+* if an activity is created with ``temporary=True`` it will be marked as
+  ``deleted=True``.  why not set the attribute directly? Whats the role of a
+  temporary activity?
+
+  * This is only used when creating *temporary facts* in order to prevent
+    proper activities beeing created for them. We don't do temporary facts, so
+    we can ommit this.
 
 Things we try to improve
 ------------------------
@@ -89,13 +99,13 @@ Things we try to improve
 * full unicode support
 * full pep8 and 257 complience
 * >=95% test coverage
-* strict and honest *seperation of concerns*. We provide just the backend, but that we do proper.
-* cleaner, more object oriented pythonic code
+* strict and honest *seperation of concerns*. We provide just the backend, but
+  that we do proper.  * cleaner, more object oriented pythonic code
 * 'one exit point' strategy for method return values. Reduce the spagettiness.
 * modular architecture.
 * focus on solid core functionality and only expand features once existing code
   meets our standart.
 * better project layout including waffle.io, codeship.com and requirements.io
-* fully integrated and focused on PyPi distribution. All you need for production,
-  test or dev comes out of the box with regular python tools.
+* fully integrated and focused on PyPi distribution. All you need for
+  production, test or dev comes out of the box with regular python tools.
 

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -1,23 +1,31 @@
 Packaging
 =========
 
-``hamsterlib`` follows the `semantic versioning <https://semver.org>`_ scheme.
-Each release is packaged and uploaded to `pypi <https://pypi.python.org/pypi/hamsterlib>`_.
-We provide a compliant ``setup.py`` which contains all the meta information relevant to users of
-``hamsterlib``. If you stumble upon any incompatibilities or dependency issue please let us know.
-If you are interested in packaging ``hamsterlib`` for your preferred distribution or in some other
-context we would love to hear from you!
+``hamsterlib`` follows the `semantic versioning <http://semver.org>`_ scheme.
+Each release is packaged and uploaded to `pypi
+<https://pypi.python.org/pypi/hamsterlib>`_.  We provide a compliant
+``setup.py`` which contains all the meta information relevant to users of
+``hamsterlib``. If you stumble upon any incompatibilities or dependency issue
+please let us know.  If you are interested in packaging ``hamsterlib`` for your
+preferred distribution or in some other context we would love to hear from you!
 
 
 About requirements/\*.txt
 -------------------------
-We do fully follow Donald Stuffts `argument <https://caremad.io/2013/07/setup-vs-requirement/>`_ that
-information given ``setup.py`` is of fundamentally different nature than what may be located under ``requirements.txt``
-(Additional comments can be found in the `packaging guide <http://python-packaging-user-guide.readthedocs.org/en/latest/requirements/>`_
-and with `Hynek Schlawack <https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/>`_).
-As far as packaging goes ``setup.py`` is authoritative. We provide a set of specific environments under
-``requirements/*`` that mainly developers and 3rd parties may find useful. This way we can easily enable contributers to get
-a suitable ``virtualenv`` running or specify our test environment in one central location.
-If for example you wanted to package ``hamsterlib`` for ``debian-stable``, it would be mighty convenient to
-just provide another requirements.txt with all the relevant dependencies pinned to what your target distro
-would provide. Now you can run the entire test suit against a reliable representation of said target system.
+We do fully follow Donald Stuffts `argument
+<http://caremad.io/2013/07/setup-vs-requirement/>`_ that information given
+``setup.py`` is of fundamentally different nature than what may be located
+under ``requirements.txt`` (Additional comments can be found in the `packaging
+guide
+<http://python-packaging-user-guide.readthedocs.io/requirements/>`_
+and with `Hynek Schlawack
+<https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/>`_).
+As far as packaging goes ``setup.py`` is authoritative. We provide a set of
+specific environments under ``requirements/*`` that mainly developers and 3rd
+parties may find useful. This way we can easily enable contributers to get a
+suitable ``virtualenv`` running or specify our test environment in one central
+location.  If for example you wanted to package ``hamsterlib`` for
+``debian-stable``, it would be mighty convenient to just provide another
+requirements.txt with all the relevant dependencies pinned to what your target
+distro would provide. Now you can run the entire test suit against a reliable
+representation of said target system.

--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -3,8 +3,8 @@ General
 
 .. class:: compact
 
-* Follow `PEP 8 <http://www.python.org/dev/peps/pep-0008/>`_ and
-  `PEP 257 <https://www.python.org/dev/peps/pep-0257/>`_.  
+* Follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ and
+  `PEP 257 <https://www.python.org/dev/peps/pep-0257/>`_.
 * Try to stick to 79 chars. When this is not enough you may use up to 99 chars.
   This is more tolerable for code than for documentation.
 * Use double quotes for human readable strings and single quotes for all other strings.
@@ -29,7 +29,7 @@ Code-style
   all-encompassing ones.
 * Use well established and maintained high quality 3rd party libraries over own
   implementations.
-* Use expressive variable names. If you have to trade off verbosity and 
+* Use expressive variable names. If you have to trade off verbosity and
   expressiveness, go for the later.
 * Assigning variables even if they are used only once can be preferable if
   expressions become clearer and less dense.
@@ -42,7 +42,7 @@ Code-style
   exceptions wherever suitable.  While this may not allways improve readability
   it tends to make debugging easier as it provides one central breaking point.
 * Methods should have the following order: special (``__foo__``) > public  >
-  private (`_foo``). 
+  private (`_foo``).
 
 Imports
 -------
@@ -72,7 +72,7 @@ Documentation
 * Use `google-style <http://www.sphinx-doc.org/en/stable/ext/example_google.html#example-google>`_
   docstrings. Sphinx's `napoleon <http://www.sphinx-doc.org/en/stable/ext/napoleon.html#module-sphinx.ext.napoleon>`_
   extension will make turn this into valid ``rst``.
-* use block comments to explain implementation 
+* use block comments to explain implementation
 
 Committing and commit messages
 ------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,29 +17,32 @@ pairs::
         'tmpfile_name': filename; under which any 'ongoing fact' will be saved
         'fact_min_delta': integer; Amount of seconds under which fact creation will be prohibited.
 
-``hamsterlib.HamsterControl`` initializes the store and provides a general logger.
-Besides that ``HamsterControl.categories``, ``HamsterControl.activities`` and 
-``HamsterControl.facts`` are the main interfaces to communicate with the storage backend.
+``hamsterlib.HamsterControl`` initializes the store and provides a general
+logger. Besides that ``HamsterControl.categories``,
+``HamsterControl.activities`` and ``HamsterControl.facts`` are the main
+interfaces to communicate with the storage backend.
 
-The second cornerstone are the dedicated classes ``Category``, ``Activity`` and ``Fact``
-which, for convinience, can be imported right from ``hamsterlib``. In particular
-``Fact.create_from_raw_fact`` might be of insterest
-They provide easy and consistent facilities to create, store and manage data relevant to
-your timetracking needs. Of particular interest is ``hamsterlib.Fact.create_from_raw``
-which allows you to pass a ``raw_fact`` string and reciceve a fully populated ``Fact``
-instance in return. The class will take care of all the tedious parsing and normalizing
-of data present in the ``raw_fact``.
+The second cornerstone are the dedicated classes ``Category``, ``Activity`` and
+``Fact`` which, for convinience, can be imported right from ``hamsterlib``. In
+particular ``Fact.create_from_raw_fact`` might be of insterest They provide
+easy and consistent facilities to create, store and manage data relevant to
+your timetracking needs. Of particular interest is
+``hamsterlib.Fact.create_from_raw`` which allows you to pass a ``raw_fact``
+string and reciceve a fully populated ``Fact`` instance in return. The class
+will take care of all the tedious parsing and normalizing of data present in
+the ``raw_fact``.
 
-For clients aiming to utilize the new and sanitized backend API a look into 
-``hamsterlib.storage`` may be worthwile. These classes describe our baseline API that
-is to be implemented by any valid backend of ours. Note that some general methods are
-provided on this level already, so backend developers don't have to each time anew.
-Of cause they are always free to overload them in order to implement solutions optimized
-to their concrete backend infrastructure.
+For clients aiming to utilize the new and sanitized backend API a look into
+``hamsterlib.storage`` may be worthwile. These classes describe our baseline
+API that is to be implemented by any valid backend of ours. Note that some
+general methods are provided on this level already, so backend developers don't
+have to each time anew.  Of cause they are always free to overload them in
+order to implement solutions optimized to their concrete backend
+infrastructure.
 
-Besides this general controler ``hamsterlib.helpers`` provides convinience functions
-that help with normalization and general intermediate computation clients may have need
-for.
+Besides this general controler ``hamsterlib.helpers`` provides convinience
+functions that help with normalization and general intermediate computation
+clients may have need for.
 
 Basic Terminology
 ------------------
@@ -48,39 +51,51 @@ The following is intended as a rough description of the basic semantics of termi
 as part of this project. For technical details please refer to the module reference, in
 particular ``hamsterlib.objects``.
 
-* *Category*: What it says on the tin. A user friendly way to group accitities that
-  relate to each other. Their names are unique.
-* *Activity*: 'What you are doing'. This is a brief and easy to remember describtion of
-  the (you guessed it) 'activity' you want to track. An *activity* can be filed under
-  a category in order to provide some structure or just stay *uncategrized*.
-  While one 'activity name' can be used with multiple *categories* it will be considered
-  as a different thing all together as far as we are concerned. E.g. an activity called
-  'meeting' filed under the 'private' category will be absolutly seperate from an activity
-  named 'meeting' filed under 'bussiness'. Within each *category*, activitynames will be
-  unique.
-* *Fact*: An actually timetracked activity. That is, an entry about 'what did you do from
-  start to end'. As such it connects an general *Activity* with timetracking information as
-  well as additional optional context infos (tags and description).
-  A *fact* is usually what you are ultimativly interested in. What shows up in your report
-  and allows you to see what you did when.
-* *ongoing fact*: Legacy hamster allowed for facts without an end to be saved to the database.
-  We do not. However, to address the common use case that a client may want to start tracking
-  an activity, but does not know its end, we provide a convinient solution so clients don't
-  have to implement this each by anew.
-  We provide an API for creating one and only one persistent *ongoing fact*. A fact without
-  specified end. This fact is treated seperatly the others in almost any regard internaly.
-  As far as the client is concerned it is however just a regular fact without specified end.
-  Fact manager methods relevant to this carry ``tmp_fact`` in their name.
+Category
+   What it says on the tin. A user friendly way to group accitities that
+   relate to each other. Their names are unique.
 
-This documentation need to be expanded, but hopefully it is enough for now to get 
-you started. For detail please see the module reference and tests.
+Activity
+   'What you are doing'. This is a brief and easy to remember describtion of
+   the (you guessed it) 'activity' you want to track. An *activity* can be
+   filed under a category in order to provide some structure or just stay
+   *uncategrized*.  While one 'activity name' can be used with multiple
+   *categories* it will be considered as a different thing all together as far
+   as we are concerned. E.g. an activity called 'meeting' filed under the
+   'private' category will be absolutly seperate from an activity named
+   'meeting' filed under 'bussiness'. Within each *category*, activitynames
+   will be unique.
+
+Fact
+   An actually timetracked activity. That is, an entry about 'what did you do
+   from start to end'. As such it connects an general *Activity* with
+   timetracking information as well as additional optional context infos (tags
+   and description).  A *fact* is usually what you are ultimativly interested
+   in. What shows up in your report and allows you to see what you did when.
+
+Ongoing fact
+   Legacy hamster allowed for facts without an end to be saved to the database.
+   We do not. However, to address the common use case that a client may want to
+   start tracking an activity, but does not know its end, we provide a
+   convinient solution so clients don't have to implement this each by anew.
+   We provide an API for creating one and only one persistent *ongoing fact*. A
+   fact without specified end. This fact is treated seperatly the others in
+   almost any regard internaly.  As far as the client is concerned it is
+   however just a regular fact without specified end.  Fact manager methods
+   relevant to this carry ``tmp_fact`` in their name.
+
+This documentation need to be expanded, but hopefully it is enough for now to
+get you started. For detail please see the module reference and tests.
 
 
 Assumptions and Premisses
 --------------------------
-As any software, we make assumptions and work on premises. Here we try to make them transparent.
-* There can be only one fact any given point in time. We do not support multiple concurrent facts.
+As any software, we make assumptions and work on premises. Here we try to make
+them transparent.
+
+* There can be only one fact any given point in time. We do not support
+  multiple concurrent facts.
 
 
 
-        
+

--- a/hamster_lib/backends/sqlalchemy/storage.py
+++ b/hamster_lib/backends/sqlalchemy/storage.py
@@ -187,7 +187,7 @@ class CategoryManager(storage.BaseCategoryManager):
         Custom version of the default method in order to provide access to alchemy instances.
 
         Args:
-            category (hamster_lib.Category: Category we want.
+            category (hamster_lib.Category): Category we want.
             raw (bool): Wether to return the AlchemyCategory instead.
 
         Returns:
@@ -414,7 +414,7 @@ class ActivityManager(storage.BaseActivityManager):
         Custom version of the default method in order to provide access to alchemy instances.
 
         Args:
-            activity (hamster_lib.Activity: Activity we want.
+            activity (hamster_lib.Activity): Activity we want.
             raw (bool): Wether to return the AlchemyActivity instead.
 
         Returns:

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -617,7 +617,7 @@ class Fact(object):
             ``False`` ``tuple.pk = False``!
 
         Returns:
-            FactTuple: Representing this categories values.
+            hamster_lib.FactTuple: Representing this categories values.
         """
         pk = self.pk
         if not include_pk:

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = py27, py34, flake8, pep257, isort
+envlist = py27, py34, flake8, pep257, isort, docs
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_lib
 whitelist_externals = make
-commands = 
+commands =
 	pip install -r requirements/dev.txt
 	make coverage
 
 [testenv:flake8]
 basepython = python3.4
-deps = 
+deps =
     flake8==2.5.4
     flake8-debugger==1.4.0
     flake8-print==2.0.2
@@ -45,6 +45,7 @@ commands =
 basepython = python3.4
 deps = doc8==0.7.0
 commands =
-    pip install -r requirements/docs.txt                                                             │~
-    make docs BUILDDIR={envtmpdir} SPHINXOPTS='-W'                                                   │~
-    make -C docs linkcheck BUILDDIR={envtmpdir} skip_install = True
+    pip install -r requirements/docs.txt
+    make docs BUILDDIR={envtmpdir} SPHINXOPTS='-W'
+#    Linkcheck is disabled until we find a way to make it work with travis
+#    make -C docs linkcheck BUILDDIR={envtmpdir}


### PR DESCRIPTION
This PR add the ``docs`` test environment to our refular tox and Travis testsuite.
As a preperation to do this this, PR also includes commits fixing minor documentation errors and warning.

Closes: #165 