### PR TITLE
[#172] Add linkchecker to 'docs' testenvironment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,3 +316,9 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# Ignore urls that don't play nice with SSL
+linkcheck_ignore = [
+    r'http://caremad.io/2013/07/setup-vs-requirement/'
+]
+

--- a/tox.ini
+++ b/tox.ini
@@ -47,5 +47,4 @@ deps = doc8==0.7.0
 commands =
     pip install -r requirements/docs.txt
     make docs BUILDDIR={envtmpdir} SPHINXOPTS='-W'
-#    Linkcheck is disabled until we find a way to make it work with travis
-#    make -C docs linkcheck BUILDDIR={envtmpdir}
+    make -C docs linkcheck BUILDDIR={envtmpdir}


### PR DESCRIPTION
Some urls don't play nice with linkchecker due to ssl issues. Until this has been sorted out in greater details they have been placed on a *ignore list* in ``docs.conf.py``.

Closes: #172