### PR TITLE
[#171]Use 'tox-travis'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,15 @@
 
 language: python
 
-env:
-  - TOXENV=py34
-  - TOXENV=py27
-  - TOXENV=flake8
-  - TOXENV=pep257
-  - TOXENV=isort
-  - TOXENV=docs
-
+python:
+  - "2.7"
+  - "3.4"
 
 before_install:
-  - pip install codecov
+  - pip install -U codecov tox-travis
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install:
-  - pip install -U tox codecov
+#install:
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 envlist = py27, py34, flake8, pep257, isort, docs
 
+[tox:travis]
+2.7 = py27
+3.4 = py34, flake8, pep257, isort, docs
+
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_lib


### PR DESCRIPTION
Make travis respect python versions per environment

By editing the new section ``tox:travis`` in ``tox.ini`` it is easily
possible to transparently control which environment is run under which
python version.
This also means that the ``basepython`` value for tox environments is ignored.

Closes: #171