### PR TITLE
Fix broken requirements/*.pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean-test:
 develop:
 	pip install -U pip setuptools wheel
 	pip install -U -e .
-	pip install -U -r requirements/dev.txt
+	pip install -U -r requirements/dev.pip
 
 lint:
 	flake8 hamster_lib tests

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -3,8 +3,8 @@
 # a reproduceable development environment. For check out ``docs/packaging``.
 # For package-requirements refer to ``setup.py``.
 
--r ./docs.txt
--r ./test.txt
+-r docs.pip
+-r test.pip
 
 bumpversion==0.5.3
 ipython==5.0.0


### PR DESCRIPTION
Commit a7c731e82579882f93c78fdd7ad8d61bfeae0a27 did a uncomplete job
changes all references to requirements/*.txt to its new *.pip
counterparts. This is remedied by this commit.