### PR TITLE
[#197] Changed 'get_config' helper to 'load_config'

### DIFF
--- a/hamster_lib/helpers/config_helpers.py
+++ b/hamster_lib/helpers/config_helpers.py
@@ -145,17 +145,11 @@ def write_config_file(config_instance, app_name=DEFAULT_APP_NAME,
     return config_instance
 
 
-def get_config_instance(fallback_config_instance, app_name=DEFAULT_APP_NAME,
-        file_name=DEFAULT_CONFIG_FILENAME):
+def load_config_file(app_name=DEFAULT_APP_NAME, file_name=DEFAULT_CONFIG_FILENAME):
     """
-    Either retrieve a ``SafeConfigParser`` instance from disk of create a fallback config.
-
-    If we can not find a config file under its expected location, we trigger creation
-    of a new default file. Either way a ``SafeConfigParser`` instance is returned.
+    Retrieve a config information from file at default location.
 
     Args:
-        fallback_config_instance: Default config instance to be written to disk if none
-            is present.
         app_name (text_type, optional): Name of the application, defaults to
         ``'projecthamster``. Allows you to use your own application specific
         namespace if you wish.
@@ -163,11 +157,11 @@ def get_config_instance(fallback_config_instance, app_name=DEFAULT_APP_NAME,
         ``config.conf``.
 
     Returns:
-        SafeConfigParser: Either the config loaded from file or an instance representing
-            the content of our newly creating default config.
+        SafeConfigParser: Config loaded from file or ``None`` if not
+            successfull.
     """
     config = SafeConfigParser()
     path = get_config_path(app_name, file_name)
     if not config.read(path):
-        config = write_config_file(fallback_config_instance, app_name, file_name=file_name)
+        config = None
     return config

--- a/tests/helpers/test_config_helpers.py
+++ b/tests/helpers/test_config_helpers.py
@@ -146,21 +146,15 @@ class TestWriteConfigFile(object):
         assert isinstance(result, SafeConfigParser)
 
 
-class TestGetConfigInstance(object):
+class TestLoadConfigFile(object):
+    """Make sure file retrival works as expected."""
+
     def test_no_file_present(self, appdirs, config_instance, mocker):
-        """Make sure a new vanilla config is written if no config is found."""
-        mocker.patch('hamster_lib.helpers.config_helpers.write_config_file')
-        config_helpers.get_config_instance(config_instance)
-        assert config_helpers.write_config_file.called
+        """Make sure we return ``None``."""
+        result = config_helpers.load_config_file()
+        assert result is None
 
-    def test_file_present(self, config_instance, config_file, mocker):
+    def test_file_present(self, config_instance, config_file):
         """Make sure we try parsing a found config file."""
-        result = config_helpers.get_config_instance(config_instance)
+        result = config_helpers.load_config_file()
         assert result == config_instance
-
-    def test_get_config_path(self, appdirs, config_instance, mocker):
-        """Make sure the config target path is constructed to our expectations."""
-        mocker.patch('hamster_lib.helpers.config_helpers.write_config_file')
-        config_helpers.get_config_instance(config_instance)
-        expectation = os.path.join(appdirs.user_config_dir, 'config.conf')
-        assert config_helpers.write_config_file.called_with(expectation)


### PR DESCRIPTION
The changed helper method limits itself to retrieval of the configparser instance if a file is present.
 Otherwise it lets the caller know. It no longer ensures that a default config is written and returned. This is the clients task if it wishes this.

Closes: #197