### PR TITLE
[#190] Add 'HamsterControl.update_config' method

### DIFF
--- a/hamster_lib/lib.py
+++ b/hamster_lib/lib.py
@@ -73,6 +73,11 @@ class HamsterControl(object):
         self.activities = self.store.activities
         self.facts = self.store.facts
 
+    def update_config(self, config):
+        """Use a new config dictionary and apply its settings."""
+        self.config = config
+        self.store = self._get_store()
+
     def _get_store(self):
         """
         Setup the store used by this controler.

--- a/tests/hamster_lib/test_lib.py
+++ b/tests/hamster_lib/test_lib.py
@@ -24,6 +24,13 @@ class TestControler:
         with pytest.raises(KeyError):
             controler._get_store()
 
+    def test_update_config(self, controler, base_config, mocker):
+        """Make sure we assign new config and get a new store."""
+        controler._get_store = mocker.MagicMock()
+        controler.update_config({})
+        assert controler.config == {}
+        assert controler._get_store.called
+
     def test_get_logger(self, controler):
         """Make sure we recieve a logger that maches our expectations."""
         logger = controler._get_logger()


### PR DESCRIPTION
This PR adds a dedicated method to update a controlers config.

This method is in charge of applying the new config to the controler.
Right now that means updating the config attribute and constructing a
new store. This should not be an issue as the store itself is not
supposed to store any state to begin with.

Closes: #190