### PR TITLE
[#198] Refactor timeinfo parsing

### DIFF
--- a/hamster_lib/backends/sqlalchemy/storage.py
+++ b/hamster_lib/backends/sqlalchemy/storage.py
@@ -1006,8 +1006,9 @@ class FactManager(storage.BaseFactManager):
 
         alchemy_fact = self.store.session.query(AlchemyFact).get(fact.pk)
         if not alchemy_fact:
+            message = _("No fact with PK: {} was found.".format(fact.pk))
             self.store.logger.error(message)
-            raise KeyError(_("No fact with PK: {} was found.".format(fact.pk)))
+            raise KeyError(message)
 
         alchemy_fact.start = fact.start
         alchemy_fact.end = fact.end

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -631,6 +631,26 @@ class TestFactManager():
         db_instance = alchemy_store.session.query(AlchemyFact).get(result.pk)
         assert db_instance.as_hamster().equal_fields(fact)
 
+    def test_update_nonexisting_fact(self, alchemy_store, alchemy_fact, new_fact_values):
+        """Make sure that trying to update a fact that does not exist raises error."""
+        fact = alchemy_fact.as_hamster()
+        new_values = new_fact_values(fact)
+        fact.start = new_values['start']
+        fact.end = new_values['end']
+        fact.pk += 100
+        with pytest.raises(KeyError):
+            alchemy_store.facts._update(fact)
+
+    def test_update_new_fact(self, alchemy_store, alchemy_fact, new_fact_values):
+        """Make sure that trying to update a new fact ,e.g. one without a pk."""
+        fact = alchemy_fact.as_hamster()
+        new_values = new_fact_values(fact)
+        fact.start = new_values['start']
+        fact.end = new_values['end']
+        fact.pk = None
+        with pytest.raises(ValueError):
+            alchemy_store.facts._update(fact)
+
     def test_update_fact_new_valid_timeframe(self, alchemy_store, alchemy_fact, new_fact_values):
         """Make sure updating an existing fact works as expected."""
         fact = alchemy_fact.as_hamster()

--- a/tests/hamster_lib/conftest.py
+++ b/tests/hamster_lib/conftest.py
@@ -164,6 +164,20 @@ def current_fact(fact_factory):
         'category': None,
         'description': None,
     }),
+    ('11:00 12:00 foo@bar', {
+        'start': convert_time_to_datetime('11:00'),
+        'end': None,
+        'activity': '12:00 foo',
+        'category': 'bar',
+        'description': None,
+    }),
+    ('rumpelratz foo@bar', {
+        'start': None,
+        'end': None,
+        'activity': 'rumpelratz foo',
+        'category': 'bar',
+        'description': None,
+    }),
     ('foo@bar', {
         'start': None,
         'end': None,
@@ -191,10 +205,18 @@ def current_fact(fact_factory):
         'category': None,
         'description': 'palimpalum',
     }),
-    ('12:00-14:14 foo@bar, palimpalum', {
+    ('12:00 - 14:14 foo@bar, palimpalum', {
         'start': convert_time_to_datetime('12:00'),
         'end': convert_time_to_datetime('14:14'),
         'activity': 'foo',
+        'category': 'bar',
+        'description': 'palimpalum',
+    }),
+    # Missing whitespace around ``-`` will prevent timeinfo from beeing parsed.
+    ('12:00-14:14 foo@bar, palimpalum', {
+        'start': None,
+        'end': None,
+        'activity': '12:00-14:14 foo',
         'category': 'bar',
         'description': 'palimpalum',
     }),
@@ -206,8 +228,6 @@ def raw_fact_parametrized(request):
 
 @pytest.fixture(params=[
     '',
-    '11:00 12:00 foo@bar',
-    'rumpelratz foo@bar',
 ])
 def invalid_raw_fact_parametrized(request):
     """Return various invalid ``raw fact`` strings."""

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -286,7 +286,7 @@ class TestFact(object):
         assert fact.tags == tag_list_valid_parametrized
 
     def test_create_from_raw_fact_valid(self, raw_fact_parametrized):
-        """Make sure the constructed ``Fact``s anatomy reflets our expectations."""
+        """Make sure the constructed ``Fact``s anatomy reflects our expectations."""
         raw_fact, expectation = raw_fact_parametrized
         fact = Fact.create_from_raw_fact(raw_fact)
         assert fact.start == expectation['start']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, flake8, pep257, isort, docs
+envlist = py27, py35, flake8, pep257, isort, docs
 
 [tox:travis]
 2.7 = py27
@@ -14,7 +14,7 @@ commands =
 	make coverage
 
 [testenv:flake8]
-basepython = python3.4
+basepython = python3
 deps =
     flake8==2.6.2
     flake8-debugger==1.4.0
@@ -24,14 +24,14 @@ skip_install = True
 commands = flake8 setup.py hamster_lib/ tests/
 
 [testenv:isort]
-basepython = python3.4
+basepython = python3
 deps = isort==4.2.5
 skip_install = True
 commands =
     isort --check-only --recursive --verbose setup.py hamster_lib/ tests/
 
 [testenv:pep257]
-basepython = python3.4
+basepython = python3
 skip_install = True
 deps =
     pep257==0.7.0
@@ -39,16 +39,17 @@ commands =
     pep257 setup.py hamster_cli/ tests/
 
 [testenv:manifest]
-basepython = python3.4
+basepython = python3
 deps = check-manifest==0.31
 skip_install = True
 commands =
     check-manifest -v
 
 [testenv:docs]
-basepython = python3.4
+basepython = python3
 deps = doc8==0.7.0
 commands =
+    python -V
     pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS='-W'
     make -C docs linkcheck BUILDDIR={envtmpdir}


### PR DESCRIPTION
This PR changes the way timeinfo is extracted and completed from a
``raw fact``.

The old ``time.parse_time_info`` helper function has been replaced by
``extract_time_info``. This function takes a raw fact string and appies
our expectation to timeinfo formatting via regexes.
The procedure looks more cumbersome than the original version *but* is
more strict/accurate. If someone with more regex mojo feels like
improving it, it shall be greatly appreciated.
Instead of using one regex with ``?`` quantifiers we use a multi stepped
approach to first check for a start time and only apply additional
filters to check for end time information. One direct consequence is
that *anything* not matching our expected format will be considered part
of the 'rest'/'activity'. Something some users expressed great interest
in if I remember correctly.

In order to use the new function as part of
``Fact.create_from_raw_fact`` we amended ``time.complete_timeframe``
with an optional ``partial`` parameter. The previous (and still default)
behaviour was that the function would complete start and end time
according to our fallback strategy no matter what. Even if the timeframe
would contain no information at all.
Setting ``partial=True`` will now cause the function to only complete
start and/or end **if** there is at least partial information present.
As a consequence ``create_from_raw_fact`` can still be used to create
Fact instances without start or end times set.

One last benefit of this new solution is that timeinfo extraction and
timeframe completion are now handled exclusively by their two respective
functions. This should greatly aid providing consistent and clear
behaviour.

Closes: #198