### PR TITLE
[#127] Support Tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,4 +323,6 @@ texinfo_documents = [
 linkcheck_ignore = [
     r'http://caremad.io/2013/07/setup-vs-requirement/'
 ]
+# Increase timeout to avoid false positives esp. on Travis-CI
+linkcheck_timeout = 30
 

--- a/hamster_lib/__init__.py
+++ b/hamster_lib/__init__.py
@@ -20,6 +20,6 @@
 """hamster-lib provides generic time tracking functionality."""
 
 from .lib import REGISTERED_BACKENDS, HamsterControl  # NOQA
-from .objects import Activity, Category, Fact  # NOQA
+from .objects import Activity, Category, Fact, Tag  # NOQA
 
 __version__ = '0.11.1'

--- a/hamster_lib/backends/sqlalchemy/__init__.py
+++ b/hamster_lib/backends/sqlalchemy/__init__.py
@@ -19,5 +19,6 @@
 
 """Submodule providing a SQLAlchemy storage backend for ``hamster-lib``."""
 
-from .objects import AlchemyActivity, AlchemyCategory, AlchemyFact  # NOQA
+from .objects import (AlchemyActivity, AlchemyCategory, AlchemyFact,  # NOQA
+                      AlchemyTag)
 from .storage import SQLAlchemyStore  # NOQA

--- a/hamster_lib/backends/sqlalchemy/storage.py
+++ b/hamster_lib/backends/sqlalchemy/storage.py
@@ -33,7 +33,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import and_, or_
 
 from . import objects
-from .objects import AlchemyActivity, AlchemyCategory, AlchemyFact
+from .objects import AlchemyActivity, AlchemyCategory, AlchemyFact, AlchemyTag
 
 
 @python_2_unicode_compatible
@@ -94,6 +94,7 @@ class SQLAlchemyStore(storage.BaseStore):
             self.session = session
         self.categories = CategoryManager(self)
         self.activities = ActivityManager(self)
+        self.tags = TagManager(self)
         self.facts = FactManager(self)
 
     def cleanup(self):
@@ -698,6 +699,232 @@ class ActivityManager(storage.BaseActivityManager):
 
 
 @python_2_unicode_compatible
+class TagManager(storage.BaseTagManager):
+    def get_or_create(self, tag, raw=False):
+        """
+        Custom version of the default method in order to provide access to alchemy instances.
+
+        Args:
+            tag (hamster_lib.Tag): Tag we want.
+            raw (bool): Wether to return the AlchemyTag instead.
+
+        Returns:
+            hamster_lib.Tag or None: Tag.
+        """
+
+        message = _("Recieved {!r} and raw={}.".format(tag, raw))
+        self.store.logger.debug(message)
+
+        try:
+            tag = self.get_by_name(tag.name, raw=raw)
+        except KeyError:
+            tag = self._add(tag, raw=raw)
+        return tag
+
+    def _add(self, tag, raw=False):
+        """
+        Add a new tag to the database.
+
+        This method should not be used by any client code. Call ``save`` to make
+        the decission wether to modify an existing entry or to add a new one is
+        done correctly..
+
+        Args:
+            tag (hamster_lib.Tag): Hamster Tag instance.
+            raw (bool): Wether to return the AlchemyTag instead.
+
+        Returns:
+            hamster_lib.Tag: Saved instance, as_hamster()
+
+        Raises:
+            ValueError: If the name to be added is already present in the db.
+            ValueError: If tag passed already got an PK. Indicating that update would
+                be more apropiate.
+        """
+
+        message = _("Recieved {!r} and raw={}.".format(tag, raw))
+        self.store.logger.debug(message)
+
+        if tag.pk:
+            message = _(
+                "The tag ('{!r}') you are trying to add already has an PK."
+                " Are you sure you do not want to ``_update`` instead?".format(tag)
+            )
+            self.store.logger.error(message)
+            raise ValueError(message)
+        alchemy_tag = AlchemyTag(pk=None, name=tag.name)
+        self.store.session.add(alchemy_tag)
+        try:
+            self.store.session.commit()
+        except IntegrityError as e:
+            message = _(
+                "An error occured! Are you sure the tag.name is not already present in our"
+                " database? Here is the full original exception: '{}'.".format(e)
+            )
+            self.store.logger.error(message)
+            raise ValueError(message)
+        self.store.logger.debug(_("'{!r}' added.".format(alchemy_tag)))
+
+        if not raw:
+            alchemy_tag = alchemy_tag.as_hamster()
+        return alchemy_tag
+
+    def _update(self, tag):
+        """
+        Update a given Tag.
+
+        Args:
+            tag (hamster_lib.Tag): Tag to be updated.
+
+        Returns:
+            hamster_lib.Tag: Updated tag.
+
+        Raises:
+            ValueError: If the new name is already taken.
+            ValueError: If tag passed does not have a PK.
+            KeyError: If no tag with passed PK was found.
+        """
+
+        message = _("Recieved {!r}.".format(tag))
+        self.store.logger.debug(message)
+
+        if not tag.pk:
+            message = _(
+                "The tag passed ('{!r}') does not seem to havea PK. We don't know"
+                "which entry to modify.".format(tag)
+            )
+            self.store.logger.error(message)
+            raise ValueError(message)
+        alchemy_tag = self.store.session.query(AlchemyTag).get(tag.pk)
+        if not alchemy_tag:
+            message = _("No tag with PK: {} was found!".format(tag.pk))
+            self.store.logger.error(message)
+            raise KeyError(message)
+        alchemy_tag.name = tag.name
+
+        try:
+            self.store.session.commit()
+        except IntegrityError as e:
+            message = _(
+                "An error occured! Are you sure the tag.name is not already present in our"
+                " database? Here is the full original exception: '{}'.".format(e)
+            )
+            self.store.logger.error(message)
+            raise ValueError(message)
+
+        return alchemy_tag.as_hamster()
+
+    def remove(self, tag):
+        """
+        Delete a given tag.
+
+        Args:
+            tag (hamster_lib.Tag): Tag to be removed.
+
+        Returns:
+            None: If everything went alright.
+
+        Raises:
+            KeyError: If the ``Tag`` can not be found by the backend.
+            ValueError: If tag passed does not have an pk.
+        """
+
+        message = _("Recieved {!r}.".format(tag))
+        self.store.logger.debug(message)
+
+        if not tag.pk:
+            message = _("PK-less Tag. Are you trying to remove a new Tag?")
+            self.store.logger.error(message)
+            raise ValueError(message)
+        alchemy_tag = self.store.session.query(AlchemyTag).get(tag.pk)
+        if not alchemy_tag:
+            message = _("``Tag`` can not be found by the backend.")
+            self.store.logger.error(message)
+            raise KeyError(message)
+        self.store.session.delete(alchemy_tag)
+        message = _("{!r} successfully deleted.".format(tag))
+        self.store.logger.debug(message)
+        self.store.session.commit()
+
+    def get(self, pk):
+        """
+        Return a tag based on their pk.
+
+        Args:
+            pk (int): PK of the tag to be retrieved.
+
+        Returns:
+            hamster_lib.Tag: Tag matching given PK.
+
+        Raises:
+            KeyError: If no such PK was found.
+
+        Note:
+            We need this for now, as the service just provides pks, not names.
+        """
+
+        message = _("Recieved PK: '{}'.".format(pk))
+        self.store.logger.debug(message)
+
+        result = self.store.session.query(AlchemyTag).get(pk)
+        if not result:
+            message = _("No tag with 'pk: {}' was found!".format(pk))
+            self.store.logger.error(message)
+            raise KeyError(message)
+        message = _("Returning {!r}.".format(result))
+        self.store.logger.debug(message)
+        return result.as_hamster()
+
+    def get_by_name(self, name, raw=False):
+        """
+        Return a tag based on its name.
+
+        Args:
+            name (str): Unique name of the tag.
+            raw (bool): Wether to return the AlchemyTag instead.
+
+
+        Returns:
+            hamster_lib.Tag: Tag of given name.
+
+        Raises:
+            KeyError: If no tag matching the name was found.
+
+        """
+
+        message = _("Recieved name: '{}', raw={}.".format(name, raw))
+        self.store.logger.debug(message)
+
+        name = text_type(name)
+        try:
+            result = self.store.session.query(AlchemyTag).filter_by(name=name).one()
+        except NoResultFound:
+            message = _("No tag with 'name: {}' was found!".format(name))
+            self.store.logger.error(message)
+            raise KeyError(message)
+
+        if not raw:
+            result = result.as_hamster()
+            self.store.logger.debug(_("Returning: {!r}.").format(result))
+        return result
+
+    def get_all(self):
+        """
+        Get all tags.
+
+        Returns:
+            list: List of all Categories present in the database, ordered by lower(name).
+        """
+
+        # We avoid the costs of always computing the length of the returned list
+        # or even spamming the logs with the enrire list. Instead we just state
+        # that we return something.
+        self.store.logger.debug(_("Returning list of all tags."))
+        return [alchemy_tag for alchemy_tag in (
+            self.store.session.query(AlchemyTag).order_by(AlchemyTag.name).all())]
+
+
+@python_2_unicode_compatible
 class FactManager(storage.BaseFactManager):
     def _add(self, fact, raw=False):
         """
@@ -731,8 +958,9 @@ class FactManager(storage.BaseFactManager):
             self.store.logger.error(message)
             raise ValueError(message)
 
-        alchemy_fact = AlchemyFact(None, None, fact.start, fact.end, fact.description, None)
+        alchemy_fact = AlchemyFact(None, None, fact.start, fact.end, fact.description)
         alchemy_fact.activity = self.store.activities.get_or_create(fact.activity, raw=True)
+        alchemy_fact.tags = [self.store.tags.get_or_create(tag, raw=True) for tag in fact.tags]
         self.store.session.add(alchemy_fact)
         self.store.session.commit()
         self.store.logger.debug(_("Added {!r}.".format(alchemy_fact)))
@@ -784,8 +1012,9 @@ class FactManager(storage.BaseFactManager):
         alchemy_fact.start = fact.start
         alchemy_fact.end = fact.end
         alchemy_fact.description = fact.description
-        # [TODO] Handle tags
         alchemy_fact.activity = self.store.activities.get_or_create(fact.activity, raw=True)
+        tags = [self.store.tags.get_or_create(tag, raw=True) for tag in fact.tags]
+        alchemy_fact.tags = tags
         self.store.session.commit()
         self.store.logger.debug(_("{!r} has been updated.".format(fact)))
         return fact

--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -59,6 +59,7 @@ class BaseStore(object):
         self.logger.addHandler(logging.NullHandler())
         self.categories = BaseCategoryManager(self)
         self.activities = BaseActivityManager(self)
+        self.tags = BaseTagManager(self)
         self.facts = BaseFactManager(self)
 
     def cleanup(self):
@@ -423,6 +424,170 @@ class BaseActivityManager(BaseManager):
         # ``__get_category_activivty`` order by lower(activity.name),
         # ``__get_activities```orders by most recent start date *and*
         # lower(activity.name).
+        raise NotImplementedError
+
+
+@python_2_unicode_compatible
+class BaseTagManager(BaseManager):
+    """Base class defining the minimal API for a TagManager implementation."""
+
+    def save(self, tag):
+        """
+        Save a Tag to our selected backend.
+        Internal code decides whether we need to add or update.
+
+        Args:
+            tag (hamster_lib.Tag): Tag instance to be saved.
+
+        Returns:
+            hamster_lib.Tag: Saved Tag
+
+        Raises:
+            TypeError: If the ``tag`` parameter is not a valid ``Tag`` instance.
+        """
+
+        if not isinstance(tag, objects.Tag):
+            message = _("You need to pass a hamster tag")
+            self.store.logger.debug(message)
+            raise TypeError(message)
+
+        self.store.logger.debug(_("'{}' has been received.".format(tag)))
+
+        # We don't check for just ``tag.pk`` because we don't want to make
+        # assumptions about the PK being an int or being >0.
+        if tag.pk or tag.pk == 0:
+            result = self._update(tag)
+        else:
+            result = self._add(tag)
+        return result
+
+    def get_or_create(self, tag):
+        """
+        Check if we already got a tag with that name, if not create one.
+
+        This is a convenience method as it seems sensible to rather implement
+        this once in our controller than having every client implementation
+        deal with it anew.
+
+        It is worth noting that the lookup completely ignores any PK contained in the
+        passed tag. This makes this suitable to just create the desired Tag
+        and pass it along. One way or the other one will end up with a persisted
+        db-backed version.
+
+        Args:
+            tag (hamster_lib.Tag or None): The categories.
+
+        Returns:
+            hamster_lib.Tag or None: The retrieved or created tag. Either way,
+                the returned Tag will contain all data from the backend, including
+                its primary key.
+        """
+
+        self.store.logger.debug(_("'{}' has been received.'.".format(tag)))
+        if tag:
+            try:
+                tag = self.get_by_name(tag)
+            except KeyError:
+                tag = objects.Tag(tag)
+                tag = self._add(tag)
+        else:
+            # We want to allow passing ``tag=None``, so we normalize here.
+            tag = None
+        return tag
+
+    def _add(self, tag):
+        """
+        Add a ``Tag`` to our backend.
+
+        Args:
+            tag (hamster_lib.Tag): ``Tag`` to be added.
+
+        Returns:
+            hamster_lib.Tag: Newly created ``Tag`` instance.
+
+        Raises:
+            ValueError: When the tag name was already present! It is supposed to be
+            unique.
+            ValueError: If tag passed already got an PK. Indicating that update would
+                be more appropriate.
+        """
+        raise NotImplementedError
+
+    def _update(self, tag):
+        """
+        Update a ``Tags`` values in our backend.
+
+        Args:
+            tag (hamster_lib.Tag): Tag to be updated.
+
+        Returns:
+            hamster_lib.Tag: The updated Tag.
+
+        Raises:
+            KeyError: If the ``Tag`` can not be found by the backend.
+            ValueError: If the ``Tag().name`` is already being used by
+                another ``Tag`` instance.
+            ValueError: If tag passed does not have a PK.
+        """
+        raise NotImplementedError
+
+    def remove(self, tag):
+        """
+        Remove a tag.
+
+        Any ``Fact`` referencing the passed tag will have this tag removed.
+
+        Args:
+            tag (hamster_lib.Tag): Tag to be updated.
+
+        Returns:
+            None: If everything went ok.
+
+        Raises:
+            KeyError: If the ``Tag`` can not be found by the backend.
+            TypeError: If tag passed is not an hamster_lib.Tag instance.
+            ValueError: If tag passed does not have an pk.
+        """
+        raise NotImplementedError
+
+    def get(self, pk):
+        """
+        Get an ``Tag`` by its primary key.
+
+        Args:
+            pk (int): Primary key of the ``Tag`` to be fetched.
+
+        Returns:
+            hamster_lib.Tag: ``Tag`` with given primary key.
+
+        Raises:
+            KeyError: If no ``Tag`` with this primary key can be found by the backend.
+        """
+
+        raise NotImplementedError
+
+    def get_by_name(self, name):
+        """
+        Look up a tag by its name.
+
+        Args:
+            name (str): Unique name of the ``Tag`` to we want to fetch.
+
+        Returns:
+            hamster_lib.Tag: ``Tag`` with given name.
+
+        Raises:
+            KeyError: If no ``Tag`` with this name was found by the backend.
+        """
+        raise NotImplementedError
+
+    def get_all(self):
+        """
+        Return a list of all tags.
+
+        Returns:
+            list: List of ``Tags``, ordered by ``lower(name)``.
+        """
         raise NotImplementedError
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ requirements = [
     'future',
     'sqlalchemy',
     'icalendar',
-    'configparser',
+    'six',
+    'configparser >= 3.5.0b2',
 ]
 
 setup(

--- a/tests/backends/sqlalchemy/test_objects.py
+++ b/tests/backends/sqlalchemy/test_objects.py
@@ -18,8 +18,9 @@ class TestAlchemyActivity(object):
         activity = alchemy_activity.as_hamster()
         assert activity.equal_fields(alchemy_activity)
 
-    def test_activity_has_facts(self, alchemy_store, alchemy_fact):
+    def test_activity_has_facts(self, alchemy_store, alchemy_fact_factory):
         """Make sure that an activity can access ``Fact`` instances."""
+        alchemy_fact = alchemy_fact_factory()
         assert alchemy_fact.activity
         activity = alchemy_fact.activity
         assert activity.facts
@@ -27,6 +28,30 @@ class TestAlchemyActivity(object):
 
 class TestAlchemyFact(object):
     """Make sure our custom methods behave properly."""
+
+    def test_adding_tags(self, alchemy_store, alchemy_fact, alchemy_tag):
+        """
+        Make sure that adding tags works as expected.
+
+        This is closer to testing we got SQLAlchemy right than actual code.
+        """
+        assert len(alchemy_fact.tags) == 4
+        alchemy_fact.tags.append(alchemy_tag)
+        assert len(alchemy_fact.tags) == 5
+        assert alchemy_tag in alchemy_fact.tags
+
+    def test_setting_tags(self, alchemy_store, alchemy_fact, alchemy_tag_factory):
+        """
+        Make sure that adding tags works as expected.
+
+        This is closer to testing we got SQLAlchemy right than actual code.
+        """
+        assert alchemy_fact.tags
+        new_tags = [alchemy_tag_factory() for i in range(5)]
+        alchemy_fact.tags = new_tags
+        assert len(alchemy_fact.tags) == 5
+        assert alchemy_fact.tags == new_tags
+
     def test_as_hamster(self, alchemy_store, alchemy_fact):
         """Make sure that conversion into a ``hamster_lib.Fact```works as expected."""
         fact = alchemy_fact.as_hamster()

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -7,7 +7,8 @@ import datetime
 import hamster_lib
 import pytest
 from hamster_lib.backends.sqlalchemy import (AlchemyActivity, AlchemyCategory,
-                                             AlchemyFact, SQLAlchemyStore)
+                                             AlchemyFact, AlchemyTag,
+                                             SQLAlchemyStore)
 
 
 # The reason we see a great deal of count == 0 statements is to make sure that
@@ -442,11 +443,153 @@ class TestActivityManager():
         assert len(result) == 1
 
 
+class TestTagManager():
+    def test_add_new(self, alchemy_store, alchemy_tag_factory):
+        """
+        Our manager methods return the persistant instance as hamster objects.
+        As we want to make sure that we compare our expectations against the
+        raw saved object, we look it up explicitly again.
+        """
+        assert alchemy_store.session.query(AlchemyTag).count() == 0
+        tag = alchemy_tag_factory.build().as_hamster()
+        tag.pk = None
+        assert alchemy_store.session.query(AlchemyTag).count() == 0
+        result = alchemy_store.tags._add(tag)
+        assert alchemy_store.session.query(AlchemyTag).count() == 1
+        db_instance = alchemy_store.session.query(AlchemyTag).get(result.pk)
+        assert tag.equal_fields(db_instance)
+        assert tag != db_instance
+
+    def test_add_existing_name(self, alchemy_store, alchemy_tag_factory):
+        """Make sure that adding a tag with a name that is already present gives an error."""
+        existing_tag = alchemy_tag_factory()
+        tag = alchemy_tag_factory.build().as_hamster()
+        tag.name = existing_tag.name
+        tag.pk = None
+        with pytest.raises(ValueError):
+            alchemy_store.tags._add(tag)
+
+    def test_add_with_pk(self, alchemy_store, alchemy_tag_factory):
+        """Make sure that adding a alchemy_tag that already got an PK raisess an exception."""
+        tag = alchemy_tag_factory().as_hamster()
+        tag.name += 'foobar'
+        assert tag.pk
+        with pytest.raises(ValueError):
+            alchemy_store.tags._add(tag)
+
+    def test_update(self, alchemy_store, alchemy_tag_factory, new_tag_values):
+        """Test that updateing a alchemy_tag works as expected."""
+        alchemy_store.session.query(AlchemyTag).count() == 0
+        tag = alchemy_tag_factory().as_hamster()
+        new_values = new_tag_values(tag)
+        for key, value in new_values.items():
+            assert getattr(tag, key) != value
+        for key, value in new_values.items():
+            setattr(tag, key, value)
+        alchemy_store.tags._update(tag)
+        db_instance = alchemy_store.session.query(AlchemyTag).get(tag.pk)
+        assert alchemy_store.session.query(AlchemyTag).count() == 1
+        assert tag.equal_fields(db_instance)
+
+    def test_update_without_pk(self, alchemy_store, alchemy_tag_factory):
+        """Make sure that passing a tag without a PK raises an error."""
+        tag = alchemy_tag_factory.build(pk=None).as_hamster()
+        with pytest.raises(ValueError):
+            alchemy_store.tags._update(tag)
+
+    def test_update_invalid_pk(self, alchemy_store, alchemy_tag_factory):
+        """Make sure that passing a tag with a non existing PK raises an error."""
+        tag = alchemy_tag_factory().as_hamster()
+        tag.pk = tag.pk + 10
+        with pytest.raises(KeyError):
+            alchemy_store.tags._update(tag)
+
+    def test_update_existing_name(self, alchemy_store, alchemy_tag_factory):
+        """Make sure that renaming a given alchemy_tag to a taken name throws an error."""
+        tag_1, tag_2 = (alchemy_tag_factory(), alchemy_tag_factory())
+        tag_2 = tag_2.as_hamster()
+        tag_2.name = tag_1.name
+        with pytest.raises(ValueError):
+            alchemy_store.tags._update(tag_2)
+
+    def test_remove(self, alchemy_store, alchemy_tag_factory):
+        """Make sure passing a valid alchemy_tag removes it from the db."""
+        tag = alchemy_tag_factory().as_hamster()
+        result = alchemy_store.tags.remove(tag)
+        assert result is None
+        assert alchemy_store.session.query(AlchemyTag).get(tag.pk) is None
+
+    def test_remove_no_pk(self, alchemy_store, alchemy_tag_factory):
+        """Ensure that passing a alchemy_tag without an PK raises an error."""
+        tag = alchemy_tag_factory.build(pk=None).as_hamster()
+        with pytest.raises(ValueError):
+            alchemy_store.tags.remove(tag)
+
+    def test_remove_invalid_pk(self, alchemy_store, alchemy_tag_factory):
+        """Ensure that passing a alchemy_tag without an PK raises an error."""
+        tag = alchemy_tag_factory.build(pk=800).as_hamster()
+        with pytest.raises(KeyError):
+            alchemy_store.tags.remove(tag)
+
+    def test_get_existing_pk(self, alchemy_store, alchemy_tag_factory):
+        """Make sure method retrieves corresponding object."""
+        tag = alchemy_tag_factory().as_hamster()
+        result = alchemy_store.tags.get(tag.pk)
+        assert result == tag
+
+    def test_get_non_existing_pk(self, alchemy_store, alchemy_tag_factory):
+        """Make sure we throw an error if PK can not be resolved."""
+        alchemy_store.session.query(AlchemyTag).count == 0
+        tag = alchemy_tag_factory()
+        alchemy_store.session.query(AlchemyTag).count == 1
+        with pytest.raises(KeyError):
+            alchemy_store.tags.get(tag.pk + 1)
+
+    def test_get_by_name(self, alchemy_tag_factory, alchemy_store):
+        """Make sure a alchemy_tag can be retrieved by name."""
+        tag = alchemy_tag_factory().as_hamster()
+        result = alchemy_store.tags.get_by_name(tag.name)
+        assert result == tag
+
+    def test_get_all(self, alchemy_store, set_of_tags):
+        result = alchemy_store.tags.get_all()
+        assert len(result) == len(set_of_tags)
+        assert len(result) == alchemy_store.session.query(AlchemyTag).count()
+        for tag in set_of_tags:
+            assert tag.as_hamster() in result
+
+    # Test convinience methods.
+    def test_get_or_create_get(self, alchemy_store, alchemy_tag_factory):
+        """Test that if we pass a alchemy_tag of existing name, we just return it."""
+        assert alchemy_store.session.query(AlchemyTag).count() == 0
+        tag = alchemy_tag_factory().as_hamster()
+        result = alchemy_store.tags.get_or_create(tag)
+        assert alchemy_store.session.query(AlchemyTag).count() == 1
+        assert result == tag
+
+    def test_get_or_create_new_name(self, alchemy_store, alchemy_tag_factory):
+        """Make sure that passing a tag with new name creates and returns new instance."""
+        assert alchemy_store.session.query(AlchemyTag).count() == 0
+        tag = alchemy_tag_factory.build().as_hamster()
+        tag.pk = None
+        result = alchemy_store.tags.get_or_create(tag)
+        assert alchemy_store.session.query(AlchemyTag).count() == 1
+        assert result.equal_fields(tag)
+
+
 class TestFactManager():
+    def test_add_tags(self, alchemy_store, fact):
+        """Make sure that adding a new valid fact will also save its tags."""
+        result = alchemy_store.facts._add(fact)
+        assert fact.tags
+        db_instance = alchemy_store.session.query(AlchemyFact).get(result.pk)
+        assert db_instance.tags
+        assert db_instance.as_hamster().equal_fields(fact)
+
     def test_add_new_valid_fact_new_activity(self, alchemy_store, fact):
         """Make sure that adding a new valid fact with a new activity works as intended."""
         assert alchemy_store.session.query(AlchemyFact).count() == 0
-        assert alchemy_store.session.query(AlchemyCategory).count() == 0
+        assert alchemy_store.session.query(AlchemyActivity).count() == 0
         result = alchemy_store.facts._add(fact)
         db_instance = alchemy_store.session.query(AlchemyFact).get(result.pk)
         assert alchemy_store.session.query(AlchemyFact).count() == 1
@@ -478,6 +621,15 @@ class TestFactManager():
         fact.end = alchemy_fact.start + datetime.timedelta(minutes=15)
         with pytest.raises(ValueError):
             alchemy_store.facts._add(fact)
+
+    def test_update_respects_tags(self, alchemy_store, alchemy_fact, new_fact_values):
+        """Make sure that updating sets tags as expected."""
+        fact = alchemy_fact.as_hamster()
+        new_values = new_fact_values(fact)
+        fact.tags = new_values['tags']
+        result = alchemy_store.facts._update(fact)
+        db_instance = alchemy_store.session.query(AlchemyFact).get(result.pk)
+        assert db_instance.as_hamster().equal_fields(fact)
 
     def test_update_fact_new_valid_timeframe(self, alchemy_store, alchemy_fact, new_fact_values):
         """Make sure updating an existing fact works as expected."""
@@ -513,13 +665,16 @@ class TestFactManager():
         assert result.description == fact.description
 
     def test_remove(self, alchemy_store, alchemy_fact):
+        """Make sire the fact but not its tags are removed."""
         count_before = alchemy_store.session.query(AlchemyFact).count()
+        tags_before = alchemy_store.session.query(AlchemyTag).count()
         fact = alchemy_fact.as_hamster()
         result = alchemy_store.facts.remove(fact)
         count_after = alchemy_store.session.query(AlchemyFact).count()
         assert count_after < count_before
         assert result is True
         assert alchemy_store.session.query(AlchemyFact).get(fact.pk) is None
+        assert alchemy_store.session.query(AlchemyTag).count() == tags_before
 
     def test_get(self, alchemy_store, alchemy_fact):
         fact = alchemy_fact.as_hamster()

--- a/tests/hamster_lib/conftest.py
+++ b/tests/hamster_lib/conftest.py
@@ -16,6 +16,7 @@ from . import factories
 
 register(factories.CategoryFactory)
 register(factories.ActivityFactory)
+register(factories.TagFactory)
 register(factories.FactFactory)
 
 faker = faker_.Faker()

--- a/tests/hamster_lib/factories.py
+++ b/tests/hamster_lib/factories.py
@@ -41,9 +41,20 @@ class ActivityFactory(factory.Factory):
 
 
 @python_2_unicode_compatible
+class TagFactory(factory.Factory):
+    """Factory providing randomized ``hamster_lib.Category`` instances."""
+
+    pk = None
+    name = factory.Faker('word')
+
+    class Meta:
+        model = objects.Tag
+
+
+@python_2_unicode_compatible
 class FactFactory(factory.Factory):
     """
-    Factory providing randomized ``hamster_lib.Category`` instances.
+    Factory providing randomized ``hamster_lib.Fact`` instances.
 
     Instances have a duration of 3 hours.
     """
@@ -56,3 +67,8 @@ class FactFactory(factory.Factory):
 
     class Meta:
         model = objects.Fact
+
+    @factory.post_generation
+    def tags(self, create, extracted, **kwargs):
+        """Add new random tags after instance creation."""
+        self.tags = set([TagFactory() for i in range(1)])

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -21,8 +21,7 @@ class TestLoadTmpFact(object):
         with pytest.raises(TypeError):
             helpers._load_tmp_fact(base_config['tmpfile_path'])
 
-    def test_valid(self, base_config, tmp_fact, fact):
+    def test_valid(self, base_config, tmp_fact):
         """Make sure that we return the stored 'ongoing fact' as expected."""
-        fact.end = None
         result = helpers._load_tmp_fact(base_config['tmpfile_path'])
-        assert result == fact
+        assert result == tmp_fact


### PR DESCRIPTION
This PR adds tags as optional information for facts to our ontology.
Facts can be used to add additional context to individual facts.

For that purpose a new ``objects.Tag`` has been added as well as a
corresponding SQLAlchemy class.

On the ``hamster`` level, ``Fact.tags`` is a set of ``objects.Tag``
instances. When a ``Fact`` is 'tupleized' this set is turned into a
``frozenset`` to be immutable.
On the SQLAlchemy level a intermediate table ``facttags`` has been
added.

Factories and fixtures have been adjusted accordingly to feature
radomized tags by default.

Because most sqlbackend related test do test that the db_instance
against the passed hamster instance it offen sufficed to make sure that
the used instance now features tags. For ``FactManager.__add``,`` __update``
and ``remove`` we added seperate tests to ensure and showcase tag related
beheviour.

Also:
* We increase timeout for checking links to prevent false positives on travis-ci

Closes: #127