### PR TITLE
[LIB-205] Fix fakerusage in sqlalchemy backend tests.

### DIFF
--- a/tests/backends/sqlalchemy/factories.py
+++ b/tests/backends/sqlalchemy/factories.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import datetime
 
 import factory
+import faker
 from hamster_lib.backends.sqlalchemy.objects import (AlchemyActivity,
                                                      AlchemyCategory,
                                                      AlchemyFact, AlchemyTag)
@@ -22,7 +23,7 @@ class AlchemyCategoryFactory(factory.alchemy.SQLAlchemyModelFactory):
     @factory.sequence
     def name(n):  # NOQA
         """Return a name that is guaranteed to be unique."""
-        return '{name} - {key}'.format(name=factory.Faker('word'), key=n)
+        return '{name} - {key}'.format(name=faker.Faker().word(), key=n)
 
     class Meta:
         model = AlchemyCategory
@@ -52,7 +53,7 @@ class AlchemyTagFactory(factory.alchemy.SQLAlchemyModelFactory):
     @factory.sequence
     def name(n):  # NOQA
         """Return a name that is guaranteed to be unique."""
-        return '{name} - {key}'.format(name=factory.Faker('word'), key=n)
+        return '{name} - {key}'.format(name=faker.Faker().word(), key=n)
 
     class Meta:
         model = AlchemyTag


### PR DESCRIPTION
Some factories do not use simple attributes but function calls
to generate their names. In those cases ``factory.Faker`` (which usually
handles all the ``LazyAttribute`` wrapping) is the wrong choice and we
need to use a regular ``faker.Faker()`` instead.

Fixes: LIB-205