### PR TITLE
[LIB-30] Validate 'helpers.time.complete_timeframe'

### DIFF
--- a/hamster_lib/helpers/time.py
+++ b/hamster_lib/helpers/time.py
@@ -287,7 +287,8 @@ def complete_timeframe(timeframe, config, partial=False):
 
     if any((timeframe.end_date, timeframe.end_time)) or not partial:
         end = complete_end(timeframe.end_date, timeframe.end_time, config)
-    return (start, end)
+
+    return validate_start_end_range((start, end))
 
 
 def parse_time(time):
@@ -322,3 +323,26 @@ def parse_time(time):
             "String does not seem to be in one of our supported time formats."
         ))
     return result
+
+
+def validate_start_end_range(range_tuple):
+    """
+    Perform basic sanity checks on a timeframe.
+
+    Args:
+        range_tuple (tuple): ``(start, end)`` tuple as returned by
+            ``complete_timeframe``.
+
+    Raises:
+        ValueError: If validation fails.
+
+    Returns:
+        tuple: ``(start, end)`` tuple that passed validation.
+    """
+
+    start, end = range_tuple
+
+    if (start and end) and (start > end):
+        raise ValueError(_("Start after end!"))
+
+    return range_tuple

--- a/hamster_lib/helpers/time.py
+++ b/hamster_lib/helpers/time.py
@@ -309,10 +309,6 @@ def parse_time(time):
         This parse just a singlular date, time or datetime representation.
     """
 
-    # [TODO]
-    # Propably should enhance error handling for invalid but correctly formated
-    # times such as '30:55' or '2015-15-60'.
-
     length = len(time.strip().split())
     if length == 1:
         try:

--- a/hamster_lib/helpers/time.py
+++ b/hamster_lib/helpers/time.py
@@ -319,6 +319,6 @@ def parse_time(time):
         result = datetime.datetime.strptime(time, '%Y-%m-%d %H:%M')
     else:
         raise ValueError(_(
-            "Sting does not seem to be in one of our supported time formats."
+            "String does not seem to be in one of our supported time formats."
         ))
     return result

--- a/tests/helpers/test_time.py
+++ b/tests/helpers/test_time.py
@@ -289,3 +289,26 @@ class TestParseTime(object):
         """Ensure that invalid times throw an exception."""
         with pytest.raises(ValueError):
             time_helpers.parse_time(time)
+
+
+class TestValidateStartEndRange(object):
+    "Unittests for validation function."""
+
+    @pytest.mark.parametrize('range', (
+        (datetime.datetime(2016, 12, 1, 12, 30), datetime.datetime(2016, 12, 1, 12, 45)),
+        (datetime.datetime(2016, 1, 1, 12, 30), datetime.datetime(2016, 12, 1, 12, 45)),
+        (datetime.datetime(2016, 1, 1, 12, 30), datetime.datetime(2016, 12, 1, 1, 45)),
+    ))
+    def test_valid_ranges(self, range):
+        """Make sure that ranges with end > start pass validation."""
+        result = time_helpers.validate_start_end_range(range)
+        assert result == range
+
+    @pytest.mark.parametrize('range', (
+        (datetime.datetime(2016, 12, 1, 12, 30), datetime.datetime(2016, 12, 1, 10, 45)),
+        (datetime.datetime(2016, 1, 13, 12, 30), datetime.datetime(2016, 1, 1, 12, 45)),
+    ))
+    def test_invalid_ranges(self, range):
+        """Make sure that ranges with start > end fail validation."""
+        with pytest.raises(ValueError):
+            time_helpers.validate_start_end_range(range)


### PR DESCRIPTION
This PR adds a very basic sanity check for the result of
``helpers.time.complete_timeframe``. A new ``validate_start_end_range``
function is used to make sure that ``start < end``.

It also includes two minor cleanup commits.

Closes: LIB-30