### PR TITLE
[LIB-220] Replace 'controler' with 'controller'

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ To use hamsterlib in a project::
     import hamsterlib
 
 The main point of entry is ``hamsterlib.HamsterControl``. Your friendly timetracking
-controler. All that is required to initialize it is that you pass it a ``dict`` with basic
+controller. All that is required to initialize it is that you pass it a ``dict`` with basic
 configuration information. Right now, all that is needed are the following key/value
 pairs::
 
@@ -40,7 +40,7 @@ have to each time anew.  Of cause they are always free to overload them in
 order to implement solutions optimized to their concrete backend
 infrastructure.
 
-Besides this general controler ``hamsterlib.helpers`` provides convinience
+Besides this general controller ``hamsterlib.helpers`` provides convenience
 functions that help with normalization and general intermediate computation
 clients may have need for.
 

--- a/hamster_lib/helpers/time.py
+++ b/hamster_lib/helpers/time.py
@@ -56,7 +56,7 @@ def end_day_to_datetime(end_day, config):
 
     Args:
         end (datetime.date): Raw end date that is to be adjusted.
-        config: Controler config containing information on when a workday starts.
+        config: Controller config containing information on when a workday starts.
 
     Returns:
         datetime.datetime: The endday as a adjusted datetime object.

--- a/hamster_lib/lib.py
+++ b/hamster_lib/lib.py
@@ -50,7 +50,7 @@ class HamsterControl(object):
     """
     All mandatory config options are set as part of the contoler setup.
     Any client may overwrite those values. but we can always asume that the
-    controler does have a value set.
+    controller does have a value set.
 
     We will try hard to get through with at least always returning the object.
     We should be able to change only the internal service code to then
@@ -60,7 +60,7 @@ class HamsterControl(object):
     and fact objects. But as all of those depend on access to the store
     anyway they seem to be best be placed here as a central hub.
 
-    Generic CRUD-actions is to be delegated to our store. The Controler itself
+    Generic CRUD-actions is to be delegated to our store. The Controller itself
     provides general timetracking functions so that our clients do not have to.
     """
 
@@ -80,7 +80,7 @@ class HamsterControl(object):
 
     def _get_store(self):
         """
-        Setup the store used by this controler.
+        Setup the store used by this controller.
 
         This method is in charge off figuring out the store type, its instantiation
         as well as all additional configuration.

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -393,7 +393,7 @@ class Fact(object):
 
         Args:
             raw_fact (str): Raw fact to be parsed.
-            config (dict, optional): Controler config provided additional settings
+            config (dict, optional): Controller config provided additional settings
                 relevant for timeframe completion.
 
         Returns:

--- a/tests/hamster_lib/conftest.py
+++ b/tests/hamster_lib/conftest.py
@@ -35,16 +35,16 @@ def convert_time_to_datetime(time_string):
     )
 
 
-# Controler
+# Controller
 
 
 @pytest.yield_fixture
-def controler(base_config):
-    """Provide a basic controler."""
+def controller(base_config):
+    """Provide a basic controller."""
     # [TODO] Parametrize over all available stores.
-    controler = HamsterControl(base_config)
-    yield controler
-    controler.store.cleanup()
+    controller = HamsterControl(base_config)
+    yield controller
+    controller.store.cleanup()
 
 
 @pytest.fixture

--- a/tests/hamster_lib/test_lib.py
+++ b/tests/hamster_lib/test_lib.py
@@ -8,32 +8,32 @@ import pytest
 from hamster_lib.storage import BaseStore
 
 
-class TestControler:
+class TestController:
     @pytest.mark.parametrize('storetype', ['sqlalchemy'])
-    def test_get_store_valid(self, controler, storetype):
+    def test_get_store_valid(self, controller, storetype):
         """Make sure  we recieve a valid ``store`` instance."""
         # [TODO]
         # Once we got backend registration up and running this should be
         # improved to check actual store type for that backend.
-        controler.config['store'] = storetype
-        assert isinstance(controler._get_store(), BaseStore)
+        controller.config['store'] = storetype
+        assert isinstance(controller._get_store(), BaseStore)
 
-    def test_get_store_invalid(self, controler):
+    def test_get_store_invalid(self, controller):
         """Make sure we get an exception if store retrieval fails."""
-        controler.config['store'] = None
+        controller.config['store'] = None
         with pytest.raises(KeyError):
-            controler._get_store()
+            controller._get_store()
 
-    def test_update_config(self, controler, base_config, mocker):
+    def test_update_config(self, controller, base_config, mocker):
         """Make sure we assign new config and get a new store."""
-        controler._get_store = mocker.MagicMock()
-        controler.update_config({})
-        assert controler.config == {}
-        assert controler._get_store.called
+        controller._get_store = mocker.MagicMock()
+        controller.update_config({})
+        assert controller.config == {}
+        assert controller._get_store.called
 
-    def test_get_logger(self, controler):
+    def test_get_logger(self, controller):
         """Make sure we recieve a logger that maches our expectations."""
-        logger = controler._get_logger()
+        logger = controller._get_logger()
         assert isinstance(logger, logging.Logger)
         assert logger.name == 'hamster-lib.log'
         # [FIXME]


### PR DESCRIPTION
This commit replaces incorrectly spelled 'controler' with 'controller' throughout the codebase. This is mostly cosmetic change, only tests and comments were affected.

Fixes: LIB-220