### PR TITLE
[LIB-109] Refactor XMLWriter attributes

### DIFF
--- a/hamster_lib/reports.py
+++ b/hamster_lib/reports.py
@@ -332,10 +332,10 @@ class XMLWriter(ReportWriter):
         Once the child is prepared append it to ``fact_list``.
         """
         fact = self.document.createElement("fact")
-        fact.setAttribute('start_time', fact_tuple.start)
-        fact.setAttribute('end_time', fact_tuple.end)
-        fact.setAttribute('name', fact_tuple.activity)
-        fact.setAttribute('duration_minutes', fact_tuple.duration)
+        fact.setAttribute('start', fact_tuple.start)
+        fact.setAttribute('end', fact_tuple.end)
+        fact.setAttribute('activity', fact_tuple.activity)
+        fact.setAttribute('duration', fact_tuple.duration)
         fact.setAttribute('category', fact_tuple.category)
         fact.setAttribute('description', fact_tuple.description)
         self.fact_list.appendChild(fact)

--- a/hamster_lib/reports.py
+++ b/hamster_lib/reports.py
@@ -282,10 +282,10 @@ class XMLWriter(ReportWriter):
     """Writer for a basic xml export."""
 
     # This is a straight forward copy of the 'legacy hamster' XMLWriter class
-    # contributet by 'tbaugis' in 11e3f66
+    # contributed by 'tbaugis' in 11e3f66
 
     def __init__(self, path, datetime_format="%Y-%m-%d %H:%M:%S"):
-        """Setúp the writer including a main xml document."""
+        """Setup the writer including a main xml document."""
         self.datetime_format = datetime_format
         self.file = open(path, 'wb')
         self.document = Document()
@@ -295,12 +295,12 @@ class XMLWriter(ReportWriter):
         """
         Convert a ``Fact`` to its normalized tuple.
 
-        This is where all type conversion for ``Fact`` attributes to strings as well
-        as any normalization happens.
+        This is where all type conversion for ``Fact`` attributes to strings as
+        well as any normalization happens.
 
         Note:
-            Because different writers may require different types, we need to so this
-            individualy.
+            Because different writers may require different types, we need to
+            do this individually.
 
         Args:
             fact (hamster_lib.Fact): Fact to be converted.
@@ -326,7 +326,11 @@ class XMLWriter(ReportWriter):
         )
 
     def _write_fact(self, fact_tuple):
-        """Create new fact element and populate attributes before appending to ``fact_list``"""
+        """
+        Create new fact element and populate attributes.
+
+        Once the child is prepared append it to ``fact_list``.
+        """
         fact = self.document.createElement("fact")
         fact.setAttribute('start_time', fact_tuple.start)
         fact.setAttribute('end_time', fact_tuple.end)
@@ -338,7 +342,7 @@ class XMLWriter(ReportWriter):
 
     def _close(self):
         """
-        Append the xml fact list to the main document, write to file and close fileobject.
+        Append the xml fact list to the main document write file and cleanup.
 
         ``toxml`` should take care of encoding everything with UTF-8.
         """

--- a/tests/hamster_lib/test_reports.py
+++ b/tests/hamster_lib/test_reports.py
@@ -212,10 +212,10 @@ class TestXMLWriter(object):
         xml_writer.fact_list.appendChild = mocker.MagicMock()
         xml_writer._write_fact(fact_tuple)
         result = xml_writer.fact_list.appendChild.call_args[0][0]
-        assert result.getAttribute('start_time') == fact_tuple.start
-        assert result.getAttribute('end_time') == fact_tuple.end
-        assert result.getAttribute('duration_minutes') == fact_tuple.duration
-        assert result.getAttribute('name') == fact_tuple.activity
+        assert result.getAttribute('start') == fact_tuple.start
+        assert result.getAttribute('end') == fact_tuple.end
+        assert result.getAttribute('duration') == fact_tuple.duration
+        assert result.getAttribute('activity') == fact_tuple.activity
         assert result.getAttribute('category') == fact_tuple.category
         assert result.getAttribute('description') == fact_tuple.description
 


### PR DESCRIPTION
We streamline our attribute names for the generate XML in order to more
clearly reflect the attributes nature as we no longer need to care about
*legacy hamster*.

A separate commit fixes some minor typos.

Closes: [LIB-109](https://projecthamster.atlassian.net/browse/LIB-109)