### PR TITLE
[LIB-132] Add 'BaseFactManager.update_tmp_fact'

### DIFF
--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -845,6 +845,43 @@ class BaseFactManager(BaseManager):
             self.store.logger.debug(_("New temporary fact started."))
         return fact
 
+    def update_tmp_fact(self, fact):
+        """
+        Update an ongoing fact.
+
+        Args:
+            fact (hamster_lib.Fact): Fact with new values.
+
+        Returns:
+            fact (hamster_lib.Fact): The updated ``Fact`` instance.
+
+        Raises:
+            TypeError: If passed fact is not an instance of ``hamster_lib.Fact``.
+            ValueError: If passed fact already has an ``end`` value and hence is
+                not a valid *ongoing fact*.
+        """
+        if not isinstance(fact, hamster_lib.Fact):
+            raise TypeError(_(
+                "Passed fact is not a proper instance of 'hamster_lib.Fact'."
+            ))
+
+        if fact.end:
+            raise ValueError(_(
+                "The passed fact seems to have an end and hence is an invalid"
+                " 'ongoing fact'."
+            ))
+        old_fact = self.get_tmp_fact()
+
+        for attribute in ('activity', 'start', 'description', 'tags'):
+            value = getattr(fact, attribute)
+            setattr(old_fact, attribute, value)
+
+        with open(self._get_tmp_fact_path(), 'wb') as fobj:
+            pickle.dump(old_fact, fobj)
+        self.store.logger.debug(_("Temporary fact updated."))
+
+        return old_fact
+
     def stop_tmp_fact(self):
         """
         Stop current 'ongoing fact'.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,12 +114,17 @@ def new_tag_values():
 
 
 @pytest.fixture
-def new_fact_values(tag_factory):
+def new_fact_values(tag_factory, activity_factory):
     """Provide guaranteed different Fact-values for a given Fact-instance."""
     def modify(fact):
+        if fact.end:
+            end = fact.end - datetime.timedelta(days=10)
+        else:
+            end = None
         return {
+            'activity': activity_factory(),
             'start': fact.start - datetime.timedelta(days=10),
-            'end': fact.end - datetime.timedelta(days=10),
+            'end': end,
             'description': fact.description + 'foobar',
             'tags': set([tag_factory() for i in range(5)])
         }

--- a/tests/hamster_lib/test_storage.py
+++ b/tests/hamster_lib/test_storage.py
@@ -360,6 +360,23 @@ class TestFactManager:
         with pytest.raises(KeyError):
             basestore.facts.get_tmp_fact()
 
+    def test_update_tmp_fact(self, basestore, tmp_fact, new_fact_values):
+        """Make sure the updated fact has the new values."""
+        updated_fact = Fact(**new_fact_values(tmp_fact))
+        result = basestore.facts.update_tmp_fact(updated_fact)
+        assert result == updated_fact
+
+    def test_update_tmp_fact_invalid_type(self, basestore):
+        """Make sure that passing a non-Fact instances raises a ``TypeError``."""
+        with pytest.raises(TypeError):
+            basestore.facts.update_tmp_fact(dict())
+
+    def test_update_tmp_fact_end(self, basestore, fact):
+        """Make sure updating with a fact that has ``Fact.end`` raises ``ValueError."""
+        fact.end = datetime.datetime.now()
+        with pytest.raises(ValueError):
+            basestore.facts.update_tmp_fact(fact)
+
     def test_cancel_tmp_fact(self, basestore, tmp_fact, fact):
         """Make sure we return the 'ongoing_fact'."""
         result = basestore.facts.cancel_tmp_fact()


### PR DESCRIPTION
This PR introduces a new ``update_tmp_fact`` method to the fact
manager. This method allows clients to modify attributes of an existing
ongoing fact.

This PR also improves the ``new_fact_values`` fixture so it now is
able to accept facts with ``Fact.end=None``.

Closes: LIB-132