### PR TITLE
[LIB-129] Add 'offset' parameter to 'stop_tmp_fact'

### DIFF
--- a/tests/hamster_lib/test_storage.py
+++ b/tests/hamster_lib/test_storage.py
@@ -334,16 +334,58 @@ class TestFactManager:
         with pytest.raises(ValueError):
             basestore.facts._start_tmp_fact(fact)
 
-    def test_stop_tmp_fact(self, basestore, base_config, tmp_fact, fact, mocker):
-        """Make sure we can stop an 'ongoing fact' and that it will have an end set."""
+    @freeze_time('2016-02-01 18:00')
+    @pytest.mark.parametrize('hint', (
+        None,
+        datetime.timedelta(minutes=10),
+        datetime.timedelta(minutes=300),
+        datetime.timedelta(seconds=-10),
+        datetime.timedelta(minutes=-10),
+        datetime.datetime(2016, 2, 1, 19),
+        datetime.datetime(2016, 2, 1, 17, 59),
+    ))
+    def test_stop_tmp_fact(self, basestore, base_config, tmp_fact, fact, hint, mocker):
+        """
+        Make sure we can stop an 'ongoing fact' and that it will have an end set.
+
+        Please note that ever so often it may happen that the factory generates
+        a tmp_fact with ``Fact.start`` so close to ``datetime.now()`` that our
+        offset will turn the end invalid. This should happen very rarely and
+        can be fixed with some elbow grease if it ever becomes an issue.
+        """
+        if hint:
+            if isinstance(hint, datetime.datetime):
+                expected_end = hint
+            else:
+                expected_end = datetime.datetime(2016, 2, 1, 18) + hint
+        else:
+            expected_end = datetime.datetime.now()
+
         basestore.facts._add = mocker.MagicMock()
-        basestore.facts.stop_tmp_fact()
+        basestore.facts.stop_tmp_fact(hint)
         assert basestore.facts._add.called
         fact_to_be_added = basestore.facts._add.call_args[0][0]
-        assert fact_to_be_added.end
+        assert fact_to_be_added.end == expected_end
         fact_to_be_added.end = None
         assert fact_to_be_added == tmp_fact
         assert os.path.exists(basestore.facts._get_tmp_fact_path()) is False
+
+    def test_stop_tmp_fact_invalid_offset_hint(self, basestore, tmp_fact):
+        """Make sure that stopping with an offset hint that results in end>start raises error."""
+        offset = (datetime.datetime.now() - tmp_fact.start).total_seconds() + 100
+        offset = datetime.timedelta(seconds=-1 * offset)
+        with pytest.raises(ValueError):
+            basestore.facts.stop_tmp_fact(offset)
+
+    def test_stop_tmp_fact_invalid_datetime_hint(self, basestore, tmp_fact):
+        """Make sure that stopping with a datetime hint that results in end>start raises error."""
+        with pytest.raises(ValueError):
+            basestore.facts.stop_tmp_fact(tmp_fact.start - datetime.timedelta(minutes=30))
+
+    def test_stop_tmp_fact_invalid_hint_type(self, basestore, tmp_fact):
+        """Make sure that passing an invalid hint type raises an error."""
+        with pytest.raises(TypeError):
+            basestore.facts.stop_tmp_fact(str())
 
     def test_stop_tmp_fact_non_existing(self, basestore):
         """Make sure that trying to call stop when there is no 'ongoing fact' raises error."""


### PR DESCRIPTION
Clients may add an optional ``end_hint`` (``datetime`` or ``timedelta``) parameter when stopping an
*ongoing fact* to influence the computed end value for the fact to be
saved.

Closes: [LIB-129](https://projecthamster.atlassian.net/browse/LIB-129)