### PR TITLE
[LIB-211] Change dateformat for str/repr(fact) to iso

### DIFF
--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -664,10 +664,10 @@ class Fact(object):
             #                    self.description or "")
 
         if self.start:
-            start = self.start.strftime("%d-%m-%Y %H:%M")
+            start = self.start.strftime("%Y-%m-%d %H:%M")
 
         if self.end:
-            end = self.end.strftime("%d-%m-%Y %H:%M")
+            end = self.end.strftime("%Y-%m-%d %H:%M")
 
         if self.start and self.end:
             result = '{} to {} {}'.format(start, end, result)
@@ -690,10 +690,10 @@ class Fact(object):
             #                    self.description or "")
 
         if self.start:
-            start = repr(self.start.strftime("%d-%m-%Y %H:%M"))
+            start = repr(self.start.strftime("%Y-%m-%d %H:%M"))
 
         if self.end:
-            end = repr(self.end.strftime("%d-%m-%Y %H:%M"))
+            end = repr(self.end.strftime("%Y-%m-%d %H:%M"))
 
         if self.start and self.end:
             result = '{} to {} {}'.format(start, end, result)

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -435,8 +435,8 @@ class TestFact(object):
 
     def test__str__(self, fact):
         expectation = '{start} to {end} {activity}@{category}, {description}'.format(
-            start=fact.start.strftime('%d-%m-%Y %H:%M'),
-            end=fact.end.strftime('%d-%m-%Y %H:%M'),
+            start=fact.start.strftime('%Y-%m-%d %H:%M'),
+            end=fact.end.strftime('%Y-%m-%d %H:%M'),
             activity=fact.activity.name,
             category=fact.category.name,
             description=fact.description
@@ -446,7 +446,7 @@ class TestFact(object):
     def test__str__no_end(self, fact):
         fact.end = None
         expectation = '{start} {activity}@{category}, {description}'.format(
-            start=fact.start.strftime('%d-%m-%Y %H:%M'),
+            start=fact.start.strftime('%Y-%m-%d %H:%M'),
             activity=fact.activity.name,
             category=fact.category.name,
             description=fact.description
@@ -466,8 +466,8 @@ class TestFact(object):
     def test__repr__(self, fact):
         """Make sure our debugging representation matches our expectations."""
         expectation = '{start} to {end} {activity}@{category}, {description}'.format(
-            start=repr(fact.start.strftime('%d-%m-%Y %H:%M')),
-            end=repr(fact.end.strftime('%d-%m-%Y %H:%M')),
+            start=repr(fact.start.strftime('%Y-%m-%d %H:%M')),
+            end=repr(fact.end.strftime('%Y-%m-%d %H:%M')),
             activity=repr(fact.activity.name),
             category=repr(fact.category.name),
             description=repr(fact.description)
@@ -482,7 +482,7 @@ class TestFact(object):
         assert isinstance(result, str)
         fact.end = None
         expectation = '{start} {activity}@{category}, {description}'.format(
-            start=repr(fact.start.strftime('%d-%m-%Y %H:%M')),
+            start=repr(fact.start.strftime('%Y-%m-%d %H:%M')),
             activity=repr(fact.activity.name),
             category=repr(fact.category.name),
             description=repr(fact.description)


### PR DESCRIPTION
This should be more in line with the format used by ``parse_raw_fact``.
Please note that still start and end are seperated by ``to`` here while
``parse_raw_fact`` uses ``-``.

Closes: [LIB-211](https://projecthamster.atlassian.net/browse/LIB-211)