### PR TITLE
[LIB-218] Use 'PYTEST_ADDOPTS' instead of 'TEST_ARGS'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,14 @@ lint:
 	flake8 hamster_lib tests
 
 test:
-	py.test $(TEST_ARGS) tests/
+	@echo "Use the PYTEST_ADDOPTS environment variable to add extra command line options."
+	py.test tests/
 
 test-all:
 	tox
 
 coverage:
-	coverage run -m pytest $(TEST_ARGS) tests
+	coverage run -m pytest tests
 	coverage report
 
 coverage-html: coverage


### PR DESCRIPTION
Instead of using our own environment variable to pass additional parameters to individual test runs this PR switches to using pytests own ``PYTEST_ADDOPTS`` variable.

Closes: [LIB-218](https://projecthamster.atlassian.net/browse/LIB-218)