### PR TITLE
[LIB-217] Extend SQLAlchemy backend test coverage for tags

### DIFF
--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -925,7 +925,7 @@ class BaseFactManager(BaseManager):
         fact = helpers._load_tmp_fact(self._get_tmp_fact_path())
         if fact:
             if fact.start > end:
-                raise ValueError(_("This fact's 'end' value seem to be before its 'start'."))
+                raise ValueError(_("The indicated 'end' value seem to be before its 'start'."))
             else:
                 fact.end = end
             result = self.save(fact)

--- a/tests/backends/sqlalchemy/test_objects.py
+++ b/tests/backends/sqlalchemy/test_objects.py
@@ -26,6 +26,14 @@ class TestAlchemyActivity(object):
         assert activity.facts
 
 
+class TestAlchemyTag(object):
+    """Make sure our custom methods behave properly."""
+    def test_as_hamster(self, alchemy_tag):
+        """Make sure that conversion into a ``hamster_lib.Tag``works as expected."""
+        tag = alchemy_tag.as_hamster()
+        assert tag.equal_fields(alchemy_tag)
+
+
 class TestAlchemyFact(object):
     """Make sure our custom methods behave properly."""
 

--- a/tests/hamster_lib/test_storage.py
+++ b/tests/hamster_lib/test_storage.py
@@ -334,30 +334,29 @@ class TestFactManager:
         with pytest.raises(ValueError):
             basestore.facts._start_tmp_fact(fact)
 
-    @freeze_time('2016-02-01 18:00')
+    @freeze_time('2019-02-01 18:00')
     @pytest.mark.parametrize('hint', (
         None,
         datetime.timedelta(minutes=10),
         datetime.timedelta(minutes=300),
         datetime.timedelta(seconds=-10),
         datetime.timedelta(minutes=-10),
-        datetime.datetime(2016, 2, 1, 19),
-        datetime.datetime(2016, 2, 1, 17, 59),
+        datetime.datetime(2019, 2, 1, 19),
+        datetime.datetime(2019, 2, 1, 17, 59),
     ))
     def test_stop_tmp_fact(self, basestore, base_config, tmp_fact, fact, hint, mocker):
         """
         Make sure we can stop an 'ongoing fact' and that it will have an end set.
 
         Please note that ever so often it may happen that the factory generates
-        a tmp_fact with ``Fact.start`` so close to ``datetime.now()`` that our
-        offset will turn the end invalid. This should happen very rarely and
-        can be fixed with some elbow grease if it ever becomes an issue.
+        a tmp_fact with ``Fact.start`` after our mocked today-date. In order to avoid
+        confusion the easies fix is to make sure the mock-today is well in the future.
         """
         if hint:
             if isinstance(hint, datetime.datetime):
                 expected_end = hint
             else:
-                expected_end = datetime.datetime(2016, 2, 1, 18) + hint
+                expected_end = datetime.datetime(2019, 2, 1, 18) + hint
         else:
             expected_end = datetime.datetime.now()
 


### PR DESCRIPTION
This PR adds a test for the backends  ``Tag.as_hamster`` method to make sure conversion works as expected.

Closes: LIB-217