### PR TITLE
[LIB-235] Refactor 'config_helpers'

### DIFF
--- a/hamster_lib/helpers/config_helpers.py
+++ b/hamster_lib/helpers/config_helpers.py
@@ -21,18 +21,47 @@ Provide functions that provide common config related functionality.
 This module provide easy to use convenience functions to handle common configuration
 related tasks. Clients can use those to provide consistent behaviour and focus on
 their specific requirements instead.
+
+The easiest way to make use of those helpers is to call ``load_config_file`` (which will also
+handle creating a new one if none exists) and ``write_config_file``.
+
+Clients may use ``backend_config_to_configparser`` and its counter part
+``configparser_to_backend_config`` to delegate conversion between a backend config dict and a
+``ConfigParser`` instance.
+
+Note:
+    Backend config key/value information:
+        store: A ``string`` indicating which store (``hamster_lib.REGISTERED_BACKENDS``) to use.
+        day_start: ``datetime.time`` that specifies the when to start a new day.
+        fact_min_delta: ``int`` specifying minimal fact duration. Facts shorter than this will be
+        rejected.
+        tmpfile_path: ``string`` indicating where the file representing the ongoing fact is to be
+        stored.
+        db_engine: ``string`` indicating which db-engine to use. Options depend on store choice.
+        db_path: ``string`` indicating where to save the db file if the selected db option saves to
+        disk. Depends on store/engine choice.
+        db_host: ``string`` indicating the host of the db server. Depends on store/engine choice.
+        db_port: ``int`` indicating the port of the db server. Depends on store/engine choice.
+        db_name: ``string`` indicating the db-name. Depends on store/engine choice.
+        db_user: ``string`` indicating the username to access the db server. Depends on
+        store/engine choice.
+        db_password: ``string`` indicating the password to access the db server. Depends on
+        store/engine choice.
+
+    Please also note that a backend *config dict* does except ``None`` / ``empty`` values, its
+    ``ConfigParser`` representation does not include those however!
 """
 
 
 from __future__ import absolute_import, unicode_literals
 
+import datetime
 import os
 
 import appdirs
+import hamster_lib
 from backports.configparser import SafeConfigParser
-
-DEFAULT_APP_NAME = 'projecthamster'
-DEFAULT_CONFIG_FILENAME = 'config.conf'
+from six import text_type
 
 
 class HamsterAppDirs(appdirs.AppDirs):
@@ -104,7 +133,12 @@ class HamsterAppDirs(appdirs.AppDirs):
         return directory
 
 
-def get_config_path(app_name=DEFAULT_APP_NAME, file_name=DEFAULT_CONFIG_FILENAME):
+DEFAULT_APP_NAME = 'projecthamster'
+DEFAULT_APPDIRS = HamsterAppDirs(DEFAULT_APP_NAME)
+DEFAULT_CONFIG_FILENAME = '{}.conf'.format(DEFAULT_APPDIRS.appname)
+
+
+def get_config_path(appdirs=DEFAULT_APPDIRS, file_name=DEFAULT_CONFIG_FILENAME):
     """
     Return the path where the config file is stored.
 
@@ -118,50 +152,230 @@ def get_config_path(app_name=DEFAULT_APP_NAME, file_name=DEFAULT_CONFIG_FILENAME
     Returns:
         str: Fully qualified path (dir & filename) where we expect the config file.
     """
-    appdirs_ = HamsterAppDirs(app_name)
-    config_dir = appdirs_.user_config_dir
-    return os.path.join(config_dir, file_name)
+    return os.path.join(appdirs.user_config_dir, file_name)
 
 
-def write_config_file(config_instance, app_name=DEFAULT_APP_NAME,
-                      file_name=DEFAULT_CONFIG_FILENAME):
+def write_config_file(config_instance, appdirs=DEFAULT_APPDIRS,
+        file_name=DEFAULT_CONFIG_FILENAME):
     """
     Write a ConfigParser instance to file at the correct location.
 
     Args:
         config_instance: Config instance to safe to file.
-        app_name (text_type, optional): Name of the application, defaults to
-        ``'projecthamster``. Allows you to use your own application specific
-        namespace if you wish.
+        appdirs (HamsterAppDirs, optional): ``HamsterAppDirs`` instance storing app/user specific
+            path information.
         file_name (text_type, optional): Name of the config file. Defaults to
-        ``config.conf``.
+        ``DEFAULT_CONFIG_FILENAME``.
 
     Returns:
         SafeConfigParser: Instance written to file.
     """
-    path = get_config_path(app_name, file_name)
+
+    path = get_config_path(appdirs, file_name)
     with open(path, 'w') as fobj:
         config_instance.write(fobj)
     return config_instance
 
 
-def load_config_file(app_name=DEFAULT_APP_NAME, file_name=DEFAULT_CONFIG_FILENAME):
+def load_config_file(appdirs=DEFAULT_APPDIRS, file_name=DEFAULT_CONFIG_FILENAME,
+        fallback_config_instance=None):
     """
-    Retrieve a config information from file at default location.
+    Retrieve config information from file at default location.
+
+    If no config file is found a new one will be created either with ``fallback_config_instance``
+    as content or if none is provided with the result of ``get_default_backend_config``.
 
     Args:
-        app_name (text_type, optional): Name of the application, defaults to
-        ``'projecthamster``. Allows you to use your own application specific
-        namespace if you wish.
+        appdirs (HamsterAppDirs, optional): ``HamsterAppDirs`` instance storing app/user specific
+            path information.
         file_name (text_type, optional): Name of the config file. Defaults to
-        ``config.conf``.
+        ``DEFAULT_CONFIG_FILENAME``.
+        fallback_config_instance (ConfigParser): Backend config that is to be used to populate the
+            config file that is created if no pre-existing one can be found.
 
     Returns:
-        SafeConfigParser: Config loaded from file or ``None`` if not
-            successfull.
+        SafeConfigParser: Config loaded from file, either from the the  pre-existing config
+            file or the one created with fallback values.
     """
+    if not fallback_config_instance:
+        fallback_config_instance = backend_config_to_configparser(
+            get_default_backend_config(appdirs)
+        )
+
     config = SafeConfigParser()
-    path = get_config_path(app_name, file_name)
+    path = get_config_path(appdirs, file_name)
     if not config.read(path):
-        config = None
+        config = write_config_file(
+            fallback_config_instance, appdirs=appdirs, file_name=file_name
+        )
     return config
+
+
+def get_default_backend_config(appdirs):
+    """
+    Return a default config dictionary.
+
+    Args:
+        appdirs (HamsterAppDirs): ``HamsterAppDirs`` instance encapsulating the apps details.
+
+    Returns:
+        dict: Dictionary with a default configuration.
+
+    Note:
+        Those defaults are independent of the particular config-store.
+    """
+    return {
+        'store': 'sqlalchemy',
+        'day_start': datetime.time(5, 30, 0),
+        'fact_min_delta': 1,
+        'tmpfile_path': os.path.join(appdirs.user_data_dir, '{}.tmp'.format(appdirs.appname)),
+        'db_engine': 'sqlite',
+        'db_path': os.path.join(appdirs.user_data_dir, '{}.sqlite'.format(appdirs.appname)),
+    }
+
+
+# [TODO]
+# Provide better error handling
+def backend_config_to_configparser(config):
+    """
+    Return a ConfigParser instance representing a given backend config dictionary.
+
+    Args:
+        config (dict): Dictionary of config key/value pairs.
+
+    Returns:
+        SafeConfigParser: SafeConfigParser instance representing config.
+
+    Note:
+        We do not provide *any* validation about mandatory values what so ever.
+    """
+    def get_store():
+        return config.get('store')
+
+    def get_day_start():
+        day_start = config.get('day_start')
+        if day_start:
+            day_start = day_start.strftime('%H:%M:%S')
+        return day_start
+
+    def get_fact_min_delta():
+        return text_type(config.get('fact_min_delta'))
+
+    def get_tmpfile_path():
+        return text_type(config.get('tmpfile_path'))
+
+    def get_db_engine():
+        return text_type(config.get('db_engine'))
+
+    def get_db_path():
+        return text_type(config.get('db_path'))
+
+    def get_db_host():
+        return text_type(config.get('db_host'))
+
+    def get_db_port():
+        return text_type(config.get('db_port'))
+
+    def get_db_name():
+        return text_type(config.get('db_name'))
+
+    def get_db_user():
+        return text_type(config.get('db_user'))
+
+    def get_db_password():
+        return text_type(config.get('db_password'))
+
+    cp_instance = SafeConfigParser()
+    cp_instance.add_section('Backend')
+    cp_instance.set('Backend', 'store', get_store())
+    cp_instance.set('Backend', 'day_start', get_day_start())
+    cp_instance.set('Backend', 'fact_min_delta', get_fact_min_delta())
+    cp_instance.set('Backend', 'tmpfile_path', get_tmpfile_path())
+    cp_instance.set('Backend', 'db_engine', get_db_engine())
+    cp_instance.set('Backend', 'db_path', get_db_path())
+    cp_instance.set('Backend', 'db_host', get_db_host())
+    cp_instance.set('Backend', 'db_port', get_db_port())
+    cp_instance.set('Backend', 'db_name', get_db_name())
+    cp_instance.set('Backend', 'db_user', get_db_user())
+    cp_instance.set('Backend', 'db_password', get_db_password())
+
+    return cp_instance
+
+
+# [TODO]
+# Provide better error handling
+# Provide validation! For this it would probably be enough to validate a config
+# dict. We do not actually need to validate a CP-instance but just its resulting
+# dict.
+def configparser_to_backend_config(cp_instance):
+    """
+    Return a config dict generated from a configparser instance.
+
+    This functions main purpose is to ensure config dict values are properly typed.
+
+    Note:
+        This can be used with any ``ConfigParser`` backend instance not just the default one
+        in order to extract its config.
+        If a key is not found in ``cp_instance`` the resulting dict will have ``None``
+        assigned to this dict key.
+    """
+    def get_store():
+        # [TODO]
+        # This should be deligated to a dedicated validation function!
+        store = cp_instance.get('Backend', 'store')
+        if store not in hamster_lib.REGISTERED_BACKENDS.keys():
+            raise ValueError(_("Unrecognized store option."))
+        return store
+
+    def get_day_start():
+        try:
+            day_start = datetime.datetime.strptime(cp_instance.get('Backend',
+                'day_start'), '%H:%M:%S').time()
+        except ValueError:
+            raise ValueError(_(
+                "We encountered an error when parsing configs 'day_start'"
+                " value! Aborting ..."
+            ))
+        return day_start
+
+    def get_fact_min_delta():
+        return cp_instance.getint('Backend', 'fact_min_delta')
+
+    def get_tmpfile_path():
+        return cp_instance.get('Backend', 'tmpfile_path')
+
+    def get_db_engine():
+        return text_type(cp_instance.get('Backend', 'db_engine'))
+
+    def get_db_path():
+        return text_type(cp_instance.get('Backend', 'db_path'))
+
+    def get_db_host():
+        return text_type(cp_instance.get('Backend', 'db_host'))
+
+    def get_db_port():
+        return cp_instance.getint('Backend', 'db_port')
+
+    def get_db_name():
+        return text_type(cp_instance.get('Backend', 'db_name'))
+
+    def get_db_user():
+        return text_type(cp_instance.get('Backend', 'db_user'))
+
+    def get_db_password():
+        return text_type(cp_instance.get('Backend', 'db_password'))
+
+    result = {
+        'store': get_store(),
+        'day_start': get_day_start(),
+        'fact_min_delta': get_fact_min_delta(),
+        'tmpfile_path': get_tmpfile_path(),
+        'db_engine': get_db_engine(),
+        'db_path': get_db_path(),
+        'db_host': get_db_host(),
+        'db_port': get_db_port(),
+        'db_name': get_db_name(),
+        'db_user': get_db_user(),
+        'db_password': get_db_password(),
+    }
+    return result

--- a/tests/helpers/conftest.py
+++ b/tests/helpers/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from backports.configparser import SafeConfigParser
 from hamster_lib.helpers import config_helpers
 from hamster_lib.helpers.time import TimeFrame
+from six import text_type
 
 
 @pytest.fixture
@@ -25,12 +26,6 @@ def filename():
 def filepath(tmpdir, filename):
     """Provide a fully qualified pathame within our tmp-dir."""
     return os.path.join(tmpdir.strpath, filename)
-
-
-@pytest.fixture
-def config_instance(request):
-    """A dummy instance of ``SafeConfigParse``."""
-    return SafeConfigParser()
 
 
 @pytest.fixture
@@ -53,10 +48,58 @@ def appdirs(mocker, tmpdir):
 
 
 @pytest.fixture
-def config_file(config_instance, appdirs):
+def backend_config(appdirs):
+    """Provide generic backend config."""
+    appdir = appdirs(config_helpers.DEFAULT_APP_NAME)
+    return config_helpers.get_default_backend_config(appdir)
+
+
+@pytest.fixture
+def configparser_instance(request):
+    """Provide a ``ConfigParser`` instance and its expected config dict."""
+    config = SafeConfigParser()
+    config.add_section('Backend')
+    config.set('Backend', 'store', 'sqlalchemy')
+    config.set('Backend', 'day_start', '05:00:00')
+    config.set('Backend', 'fact_min_delta', '60')
+    config.set('Backend', 'tmpfile_path', '/tmp')
+    config.set('Backend', 'db_engine', 'sqlite')
+    config.set('Backend', 'db_path', '/tmp/hamster.db')
+    config.set('Backend', 'db_host', 'www.example.com')
+    config.set('Backend', 'db_port', '22')
+    config.set('Backend', 'db_name', 'hamster')
+    config.set('Backend', 'db_user', 'hamster')
+    config.set('Backend', 'db_password', 'hamster')
+
+    expectation = {
+        'store': text_type('sqlalchemy'),
+        'day_start': datetime.datetime.strptime('05:00:00', '%H:%M:%S').time(),
+        'fact_min_delta': 60,
+        'tmpfile_path': text_type('/tmp'),
+        'db_engine': text_type('sqlite'),
+        'db_path': text_type('/tmp/hamster.db'),
+        'db_host': text_type('www.example.com'),
+        'db_port': 22,
+        'db_name': text_type('hamster'),
+        'db_user': text_type('hamster'),
+        'db_password': text_type('hamster'),
+    }
+
+    return config, expectation
+
+
+@pytest.fixture
+def config_instance(request):
+    """A dummy instance of ``SafeConfigParser``."""
+    return SafeConfigParser()
+
+
+@pytest.fixture
+def config_file(backend_config, appdirs):
     """Provide a config file stored under our fake config dir."""
     with codecs.open(os.path.join(appdirs.user_config_dir, 'config.conf'),
             'w', encoding='utf-8') as fobj:
+        config_helpers.backend_config_to_configparser(backend_config).write(fobj)
         config_instance.write(fobj)
 
 

--- a/tests/helpers/test_config_helpers.py
+++ b/tests/helpers/test_config_helpers.py
@@ -120,9 +120,9 @@ class TestHamsterAppDirs(object):
 class TestGetConfigPath(object):
     """Test config pathj retrieval."""
 
-    def test_get_config_path(self, appdirs, mocker):
+    def test_get_config_path(self, appdirs):
         """Make sure the config target path is constructed to our expectations."""
-        expectation = os.path.join(appdirs.user_config_dir, 'config.conf')
+        expectation = os.path.join(appdirs.user_config_dir, config_helpers.DEFAULT_CONFIG_FILENAME)
         result = config_helpers.get_config_path()
         assert result == expectation
 
@@ -149,12 +149,27 @@ class TestWriteConfigFile(object):
 class TestLoadConfigFile(object):
     """Make sure file retrival works as expected."""
 
-    def test_no_file_present(self, appdirs, config_instance, mocker):
-        """Make sure we return ``None``."""
-        result = config_helpers.load_config_file()
-        assert result is None
+    def test_no_file_present(self, appdirs, config_instance):
+        """
+        Make sure we return ``None``.
 
-    def test_file_present(self, config_instance, config_file):
+        Notw:
+            We use the ``appdirs`` fixture to make sure the required dirs exist.
+        """
+        result = config_helpers.load_config_file(fallback_config_instance=config_instance)
+        assert result == config_instance
+
+    def test_file_present(self, config_instance, backend_config):
         """Make sure we try parsing a found config file."""
         result = config_helpers.load_config_file()
-        assert result == config_instance
+        assert result == config_helpers.backend_config_to_configparser(backend_config)
+
+
+class TestConfigParserToBackendConfig(object):
+    """Make sure that conversion works expected."""
+
+    def test_regular_usecase(self, configparser_instance):
+        """Make sure basic mechanics work and int/time types are created."""
+        cp_instance, expectation = configparser_instance
+        result = config_helpers.configparser_to_backend_config(cp_instance)
+        assert result == expectation


### PR DESCRIPTION
This commit cleans up our existing config related helper code as well as
providing a additional more unified interfaces to deal with storage and
retrieval of backend config information.
As mentioned in the module documentation, clients main way to make use
of those helpers is to call upon ``load_config_file`` and
``write_config_file``.

In most function signatures we changed ``appname`` for ``appdirs`` as
there is no point instantiating appdirs within each function anew.
Instead we create one appdir instance holding all the relevant
informantion and pass this allong.

Unlike before ``load_config_file`` will now allways return a
``ConfigParser`` instance, either from an existing config file or one
writen to a new config file using the fallback strategy. That also
means that calling ``load_config_file`` now always ensures that a
minimal config file exists afterwards.

A newly added ``get_default_backend_config`` function provides a central
definition of the minimal backend fallback config. It is worth noting
that this is just providing the config dict and hence is not tied to a
specific config store.

Lastly, ``configparser_to_backend_config`` and
``backend_config_to_configparser`` have been added to provide a central
place for converting a backend config dict to its configparser instance
and vice visa. If new backend config key/values are added those
functions are the only place where adjustments need to be made.

Also:
    - Extend documentation for ``helpers.config_helpers``.
    - Introduce ``DEFAULT_APP_NAME`` and ``DEFAULT_CONFIG_FILENAME``.

Closes: [LIB-235](https://projecthamster.atlassian.net/browse/LIB-235)