### PR TITLE
setup: Only require configparser when native version unavailable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ requirements = [
     'sqlalchemy',
     'icalendar',
     'six',
-    'configparser >= 3.5.0b2',
 ]
+
+try:
+    import configparser # noqa
+except ImportError:
+    requirements.append('configparser >= 3.5.0b2')
 
 setup(
     name='hamster-lib',


### PR DESCRIPTION
On Python 3, configparser library is part of standard library. The configparser package therefore is not needed. For this reason, distributions such as Arch Linux do not even provide this package for Python 3, which in turn breaks the build.

This patch changes the setup.py to only add the configparser dependency when native configparser is not available.