### PR TITLE
[LIB-250] Remove check for start-timeinfo when validating timeframes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-
-
-
 codecov:
   branch: develop
   notify:
@@ -23,16 +20,13 @@ coverage:
     project:
       default:
         target: auto
-        threshold: null
+        threshold: 0.1%
         branches: null
         base: auto
         set_pending: yes
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: error
-        only_pulls: null
-        flags: null
-        paths: null
 
 
 comment:

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -17,7 +17,7 @@ We do fully follow Donald Stuffts `argument
 ``setup.py`` is of fundamentally different nature than what may be located
 under ``requirements.txt`` (Additional comments can be found in the `packaging
 guide
-<http://python-packaging-user-guide.readthedocs.io/requirements/>`_
+<http://python-packaging-user-guide.readthedocs.io/discussions/install-requires-vs-requirements/>`_
 and with `Hynek Schlawack
 <https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/>`_).
 As far as packaging goes ``setup.py`` is authoritative. We provide a set of

--- a/hamster_lib/helpers/time.py
+++ b/hamster_lib/helpers/time.py
@@ -334,16 +334,17 @@ def validate_start_end_range(range_tuple):
             ``complete_timeframe``.
 
     Raises:
-        ValueError: If validation fails.
+        ValueError: If start > end.
 
     Returns:
         tuple: ``(start, end)`` tuple that passed validation.
+
+    Note:
+        ``timeframes`` may be incomplete, especially if ``complete_timeframe(partial=True)`` has
+        been used to construct them.
     """
 
     start, end = range_tuple
-
-    if not start:
-        raise ValueError(_("Start missing."))
 
     if (start and end) and (start > end):
         raise ValueError(_("Start after end!"))

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -408,6 +408,8 @@ class Fact(object):
 
         start, end = time_helpers.complete_timeframe(extracted_components['timeinfo'],
             config, partial=True)
+        # Please note that start/end may very well be ``None`` due to the
+        # partial completion!
         start, end = time_helpers.validate_start_end_range((start, end))
 
         activity_name = extracted_components['activity']

--- a/tests/hamster_lib/conftest.py
+++ b/tests/hamster_lib/conftest.py
@@ -157,8 +157,22 @@ def current_fact(fact_factory):
 
 
 @pytest.fixture(params=[
-    '',
+    '12:00 - 14:00 foo@bar, rumpelratz',
+    '12:00 - 14:00 foo',
+    'foo@bar',
+    # For the following there should not be successful start/end parsing but
+    # instead just one big "activity.name, but it still constitutes a formally
+    # valid fact. If we want to be more accurate we need to work with clear
+    # expectations.
     '12:00-14:00 foo@bar',
+])
+def valid_raw_fact_parametrized(request):
+    """Return various invalid ``raw fact`` strings."""
+    return request.param
+
+
+@pytest.fixture(params=[
+    '',
     '14:00 - 12:00 foo@bar',
     '12:00 - 14:00 @bar',
 ])

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -290,6 +290,7 @@ class TestFact(object):
     @pytest.mark.parametrize('raw_fact', (
         '12:00 - 14:00 foo@bar, rumpelratz',
         '12:00 - 14:00 foo',
+        'foo@bar',
     ))
     def test_create_from_raw_fact_valid(self, raw_fact):
         """Make sure that a valid raw fact creates a proper Fact."""

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -287,14 +287,9 @@ class TestFact(object):
         assert fact.end == start_end_datetimes[1]
         assert fact.tags == tag_list_valid_parametrized
 
-    @pytest.mark.parametrize('raw_fact', (
-        '12:00 - 14:00 foo@bar, rumpelratz',
-        '12:00 - 14:00 foo',
-        'foo@bar',
-    ))
-    def test_create_from_raw_fact_valid(self, raw_fact):
+    def test_create_from_raw_fact_valid(self, valid_raw_fact_parametrized):
         """Make sure that a valid raw fact creates a proper Fact."""
-        assert Fact.create_from_raw_fact(raw_fact)
+        assert Fact.create_from_raw_fact(valid_raw_fact_parametrized)
 
     def test_create_from_raw_fact_invalid(self, invalid_raw_fact_parametrized):
         """Make sure invalid string raises an exception."""


### PR DESCRIPTION
Closes: LIB-250