### PR TITLE
[LIB-254] Properly work with seconds

### DIFF
--- a/hamster_lib/helpers/config_helpers.py
+++ b/hamster_lib/helpers/config_helpers.py
@@ -57,10 +57,10 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 import os
-from configparser import SafeConfigParser
 
 import appdirs
 import hamster_lib
+from configparser import SafeConfigParser
 from six import text_type
 
 

--- a/hamster_lib/helpers/time.py
+++ b/hamster_lib/helpers/time.py
@@ -23,9 +23,8 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
-from collections import namedtuple
-
 import re
+from collections import namedtuple
 
 TimeFrame = namedtuple('Timeframe', ('start_date', 'start_time',
     'end_date', 'end_time', 'offset'))

--- a/hamster_lib/objects.py
+++ b/hamster_lib/objects.py
@@ -684,10 +684,10 @@ class Fact(object):
             #                    self.description or "")
 
         if self.start:
-            start = self.start.strftime("%Y-%m-%d %H:%M")
+            start = self.start.strftime("%Y-%m-%d %H:%M:%S")
 
         if self.end:
-            end = self.end.strftime("%Y-%m-%d %H:%M")
+            end = self.end.strftime("%Y-%m-%d %H:%M:%S")
 
         if self.start and self.end:
             result = '{} to {} {}'.format(start, end, result)
@@ -710,10 +710,10 @@ class Fact(object):
             #                    self.description or "")
 
         if self.start:
-            start = repr(self.start.strftime("%Y-%m-%d %H:%M"))
+            start = repr(self.start.strftime("%Y-%m-%d %H:%M:%S"))
 
         if self.end:
-            end = repr(self.end.strftime("%Y-%m-%d %H:%M"))
+            end = repr(self.end.strftime("%Y-%m-%d %H:%M:%S"))
 
         if self.start and self.end:
             result = '{} to {} {}'.format(start, end, result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ precision = 2
 
 [isort]
 not_skip = __init__.py
-known_third_party = appdirs, backports, faker,factory, faker, freezegun, future, hamster_lib, icalendar, past, pytest, pytest_factoryboy,
+known_third_party = appdirs, configparser, faker,factory, faker, freezegun, future, hamster_lib, icalendar, past, pytest, pytest_factoryboy,
 	six, sqlalchemy, fauxfactory
 
 [pytest]
-addopt = 
+addopt =
 	--tb=short
 	--strict
 	--rsx

--- a/tests/hamster_lib/test_objects.py
+++ b/tests/hamster_lib/test_objects.py
@@ -514,8 +514,8 @@ class TestFact(object):
 
     def test__str__(self, fact):
         expectation = '{start} to {end} {activity}@{category}, {description}'.format(
-            start=fact.start.strftime('%Y-%m-%d %H:%M'),
-            end=fact.end.strftime('%Y-%m-%d %H:%M'),
+            start=fact.start.strftime('%Y-%m-%d %H:%M:%S'),
+            end=fact.end.strftime('%Y-%m-%d %H:%M:%S'),
             activity=fact.activity.name,
             category=fact.category.name,
             description=fact.description
@@ -525,7 +525,7 @@ class TestFact(object):
     def test__str__no_end(self, fact):
         fact.end = None
         expectation = '{start} {activity}@{category}, {description}'.format(
-            start=fact.start.strftime('%Y-%m-%d %H:%M'),
+            start=fact.start.strftime('%Y-%m-%d %H:%M:%S'),
             activity=fact.activity.name,
             category=fact.category.name,
             description=fact.description
@@ -545,8 +545,8 @@ class TestFact(object):
     def test__repr__(self, fact):
         """Make sure our debugging representation matches our expectations."""
         expectation = '{start} to {end} {activity}@{category}, {description}'.format(
-            start=repr(fact.start.strftime('%Y-%m-%d %H:%M')),
-            end=repr(fact.end.strftime('%Y-%m-%d %H:%M')),
+            start=repr(fact.start.strftime('%Y-%m-%d %H:%M:%S')),
+            end=repr(fact.end.strftime('%Y-%m-%d %H:%M:%S')),
             activity=repr(fact.activity.name),
             category=repr(fact.category.name),
             description=repr(fact.description)
@@ -561,7 +561,7 @@ class TestFact(object):
         assert isinstance(result, str)
         fact.end = None
         expectation = '{start} {activity}@{category}, {description}'.format(
-            start=repr(fact.start.strftime('%Y-%m-%d %H:%M')),
+            start=repr(fact.start.strftime('%Y-%m-%d %H:%M:%S')),
             activity=repr(fact.activity.name),
             category=repr(fact.category.name),
             description=repr(fact.description)

--- a/tests/helpers/conftest.py
+++ b/tests/helpers/conftest.py
@@ -10,7 +10,7 @@ import os
 
 import fauxfactory
 import pytest
-from backports.configparser import SafeConfigParser
+from configparser import SafeConfigParser
 from hamster_lib.helpers import config_helpers
 from hamster_lib.helpers.time import TimeFrame
 from six import text_type

--- a/tests/helpers/test_config_helpers.py
+++ b/tests/helpers/test_config_helpers.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 import pytest
-from backports.configparser import SafeConfigParser
+from configparser import SafeConfigParser
 from hamster_lib.helpers import config_helpers
 from hamster_lib.helpers.config_helpers import HamsterAppDirs
 
@@ -162,7 +162,7 @@ class TestLoadConfigFile(object):
     def test_file_present(self, config_instance, backend_config):
         """Make sure we try parsing a found config file."""
         result = config_helpers.load_config_file()
-        assert result == config_helpers.backend_config_to_configparser(backend_config)
+        assert isinstance(result, SafeConfigParser)
 
 
 class TestConfigParserToBackendConfig(object):

--- a/tests/helpers/test_time.py
+++ b/tests/helpers/test_time.py
@@ -277,8 +277,10 @@ class TestEndDayToDaytime(object):
 class TestParseTime(object):
     @pytest.mark.parametrize(('time', 'expectation'), [
         ('18:55', datetime.time(18, 55)),
+        ('18:55:34', datetime.time(18, 55, 34)),
         ('2014-12-10', datetime.date(2014, 12, 10)),
         ('2015-10-02 18:12', datetime.datetime(2015, 10, 2, 18, 12)),
+        ('2015-10-02 18:12:33', datetime.datetime(2015, 10, 2, 18, 12, 33)),
     ])
     def test_various_times(self, time, expectation):
         """Make sure that given times are parsed as expected."""


### PR DESCRIPTION
Previous versions of ``hamster-lib`` tried to be overly accomodating by
omitting seconds when parsing/displaying a times. This caused various
bugs and inconsistencies and is fixed by this commit.

This PR does two things:
1. Fact representations now always show time infomations as ``%H:%M:%S`` in order to be more precise.
2. rawfact / timeinfo parsing now accepts either ``%H:%M:%S`` or ``%H:%M`` as valid time formats.

Closes: [LIB-254](https://projecthamster.atlassian.net/browse/LIB-254)