### PR TITLE
[LIB-253] Fix 'FactManager._get_all()'

### DIFF
--- a/hamster_lib/backends/sqlalchemy/storage.py
+++ b/hamster_lib/backends/sqlalchemy/storage.py
@@ -929,7 +929,11 @@ class FactManager(storage.BaseFactManager):
 
     def _timeframe_available_for_fact(self, fact):
         """
-        Determine if a timeframe given by the passed fact is already occupied.abs
+        Determine if a timeframe given by the passed fact is already occupied.
+
+        This method takes also such facts into account that start before and end
+        after the fact in question. In that regard it exceeds what ``_get_all``
+        would return.
 
         Args:
             fact (Fact): The fact to check. Please note that the fact is expected to
@@ -1125,7 +1129,8 @@ class FactManager(storage.BaseFactManager):
                 ``Activity.name`` or ``Category.name``.
             partial (bool): If ``False`` only facts which start *and* end
                 within the timeframe will be considered. If ``False`` facts
-                either ``start``, ``end`` or both will be returned.
+                with either ``start``, ``end`` or both within the timeframe
+                will be returned.
 
         Returns:
             list: List of ``hamster_lib.Facts`` instances.

--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -726,6 +726,8 @@ class BaseFactManager(BaseManager):
                 backend query is handled by ``_get_all``.
             * ``search_term`` should be prefixable with ``not`` in order to invert matching.
             * This does only return proper facts and does not include any existing 'ongoing fact'.
+            * This method will *NOT* return facts that start before and end after
+              (e.g. that span more than) the specified timeframe.
         """
         self.store.logger.debug(_(
             "Start: '{start}', end: {end} with filter: {filter} has been received.".format(

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -578,7 +578,7 @@ class TestFactManager():
     def test_timeframe_available_existing_fact_overlaps_start_only(self, alchemy_store, fact,
             alchemy_fact):
         """
-        Make sure that passing a fact with only start overlaping an existing one raises error.
+        Make sure that passing a fact with only start overlapping an existing one raises error.
         """
         fact.start = alchemy_fact.start - datetime.timedelta(days=4)
         fact.end = alchemy_fact.start + datetime.timedelta(minutes=15)
@@ -588,7 +588,7 @@ class TestFactManager():
     def test_timeframe_available_existing_fact_overlaps_end_only(self, alchemy_store, fact,
             alchemy_fact):
         """
-        Make sure that passing a fact with only start overlaping an existing one raises error.
+        Make sure that passing a fact with only end overlapping an existing one raises error.
         """
         fact.start = alchemy_fact.end - datetime.timedelta(minutes=1)
         fact.end = alchemy_fact.end + datetime.timedelta(minutes=15)
@@ -599,7 +599,7 @@ class TestFactManager():
     def test_timeframe_available_fact_completely_within_existing_timeframe(self, alchemy_store,
             fact, alchemy_fact):
         """
-        Make sure that passing a fact that is comepletly within an existing ones raises an error.
+        Make sure that passing a fact that is completely within an existing ones raises error.
         """
         fact.start = alchemy_fact.start + datetime.timedelta(minutes=1)
         fact.end = alchemy_fact.end - datetime.timedelta(minutes=1)
@@ -609,7 +609,7 @@ class TestFactManager():
     def test_timeframe_available_existing_fact_completly_spans_existing_timeframe(self,
             alchemy_store, fact, alchemy_fact):
         """
-        Make sure that passing a fact that completly spans an existing fact raises an error.
+        Make sure that passing a fact that completely spans an existing fact raises an error.
         """
         fact.start = alchemy_fact.start - datetime.timedelta(minutes=1)
         fact.end = alchemy_fact.end + datetime.timedelta(minutes=15)

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import datetime
 
-import hamster_lib
 import pytest
 from hamster_lib.backends.sqlalchemy import (AlchemyActivity, AlchemyCategory,
                                              AlchemyFact, AlchemyTag,
@@ -597,8 +596,8 @@ class TestFactManager():
             alchemy_store.facts._add(fact)
 
     # Testcase for Bug LIB-253
-    def test_timeframe_available_fact_completely_within_existing_timeframe(self, alchemy_store, fact,
-            alchemy_fact):
+    def test_timeframe_available_fact_completely_within_existing_timeframe(self, alchemy_store,
+            fact, alchemy_fact):
         """
         Make sure that passing a fact that is comepletly within an existing ones raises an error.
         """

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -620,6 +620,16 @@ class TestFactManager():
         with pytest.raises(ValueError):
             alchemy_store.facts._add(fact)
 
+    # Testcase for Bug LIB-253
+    def test_add_occupied_timewindow2(self, alchemy_store, fact, alchemy_fact):
+        """
+        Make sure that passing a fact with a timewindow that already has a fact raises error.
+        """
+        fact.start = alchemy_fact.start + datetime.timedelta(minutes=1)
+        fact.end = alchemy_fact.end - datetime.timedelta(minutes=1)
+        with pytest.raises(ValueError):
+            alchemy_store.facts._add(fact)
+
     def test_update_respects_tags(self, alchemy_store, alchemy_fact, new_fact_values):
         """Make sure that updating sets tags as expected."""
         fact = alchemy_fact.as_hamster()

--- a/tests/backends/sqlalchemy/test_storage.py
+++ b/tests/backends/sqlalchemy/test_storage.py
@@ -597,7 +597,7 @@ class TestFactManager():
             alchemy_store.facts._add(fact)
 
     # Testcase for Bug LIB-253
-    def test_timeframe_available_fact_completely_with_existing_timeframe(self, alchemy_store, fact,
+    def test_timeframe_available_fact_completely_within_existing_timeframe(self, alchemy_store, fact,
             alchemy_fact):
         """
         Make sure that passing a fact that is comepletly within an existing ones raises an error.
@@ -616,35 +616,6 @@ class TestFactManager():
         fact.end = alchemy_fact.end + datetime.timedelta(minutes=15)
         with pytest.raises(ValueError):
             alchemy_store.facts._add(fact)
-    #####################
-
-    def test_timeframe_available_fact_new_valid_timeframe(self, alchemy_store, alchemy_fact,
-            new_fact_values):
-        """Make sure updating an existing fact works as expected."""
-        fact = alchemy_fact.as_hamster()
-        new_values = new_fact_values(fact)
-        fact.pk = alchemy_fact.pk
-        fact.start = new_values['start']
-        fact.end = new_values['end']
-        old_fact_count = alchemy_store.session.query(AlchemyFact).count()
-        old_alchemy_activity_count = alchemy_store.session.query(AlchemyCategory).count()
-        result = alchemy_store.facts._update(fact)
-        db_instance = alchemy_store.session.query(AlchemyFact).get(result.pk)
-        new_fact_count = alchemy_store.session.query(AlchemyFact).count()
-        new_alchemy_activity_count = alchemy_store.session.query(AlchemyActivity).count()
-        assert old_fact_count == new_fact_count
-        assert old_alchemy_activity_count == new_alchemy_activity_count
-        assert db_instance.as_hamster().equal_fields(fact)
-
-    def test_timeframe_available_fact_with_same_timeframe(self, alchemy_store, alchemy_fact):
-        """Make sure we can update a fact with unchanged start/end times."""
-        fact = alchemy_fact.as_hamster()
-        fact.description = 'foobar'
-        assert isinstance(fact, hamster_lib.Fact)
-        result = alchemy_store.facts._update(fact)
-        assert result.description == fact.description
-
-    #############
 
     def test_add_tags(self, alchemy_store, fact):
         """Make sure that adding a new valid fact will also save its tags."""


### PR DESCRIPTION
``FactManager._get_all`` of the SQLAlchemy backend did not always return all partial overlaps even if ``partial=True``. As a consequence it was possible to create new facts that overlapped with existing ones.

Besides fixing the actual problem this PR also moved the 'check for timetrame availability' functionality to a dedicated private method to be used by ``_add`` and ``_update``.

Closes: LIB-253