### PR TITLE
Make the config filter a little more robust about what it accepts

### DIFF
--- a/hamster_lib/helpers/config_helpers.py
+++ b/hamster_lib/helpers/config_helpers.py
@@ -152,6 +152,8 @@ def get_config_path(appdirs=DEFAULT_APPDIRS, file_name=DEFAULT_CONFIG_FILENAME):
     Returns:
         str: Fully qualified path (dir & filename) where we expect the config file.
     """
+    if isinstance(appdirs, (str, unicode)):
+        appdirs = HamsterAppDirs(appdirs)
     return os.path.join(appdirs.user_config_dir, file_name)
 
 


### PR DESCRIPTION
Without this, hamster-gtk caused an error on Ubuntu 16.04 via virtualenv -> python2.7 + vext.gi