### PR TITLE
[pytest] => [tool.pytest]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ not_skip = __init__.py
 known_third_party = appdirs, configparser, faker,factory, faker, freezegun, future, hamster_lib, icalendar, past, pytest, pytest_factoryboy,
 	six, sqlalchemy, fauxfactory
 
-[pytest]
-addopt = 
+[tool.pytest]
+addopt =
 	--tb=short
 	--strict
 	--rsx


### PR DESCRIPTION
This commit avoids a warning:
  [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.

The `addopt` line was stripped of a trailing whitespace automatically,
due to the `.editorconfig` setting.
