### PR TITLE
[#244] Bring test suite up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@
 language: python
 
 python:
-  - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 
 before_install:
   - pip install -U codecov tox-travis

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,5 +14,5 @@ Code taken from 'legacy hamster'
 --------------------------------
 
 * `tbaugis / tstriker <https://github.com/tstriker>`_:
-  * ``parse_time_info`` from `hamster-cli <https://github.com/projecthamster/hamster/blob/master/src/hamster-cli>`_
-  * ``XMLWriter`` from `hamster <https://github.com/projecthamster/hamster/blame/master/src/hamster/reports.py>`_
+  * ``parse_time_info`` from legacy hamster-cli
+  * ``XMLWriter`` from legacy hamster

--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -69,7 +69,7 @@ Documentation
 * Docstrings should be provided for all public and private classes, methods and
   functions. Simple local functions may go without. They should elaborate the
   methods signature and use.
-* Use `google-style <http://www.sphinx-doc.org/en/stable/ext/example_google.html#example-google>`_
+* Use `google-style <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_
   docstrings. Sphinx's `napoleon <http://www.sphinx-doc.org/en/stable/ext/napoleon.html#module-sphinx.ext.napoleon>`_
   extension will make turn this into valid ``rst``.
 * use block comments to explain implementation

--- a/hamster_lib/helpers/config_helpers.py
+++ b/hamster_lib/helpers/config_helpers.py
@@ -57,10 +57,10 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 import os
+from configparser import ConfigParser
 
 import appdirs
 import hamster_lib
-from configparser import SafeConfigParser
 from six import text_type
 
 
@@ -168,7 +168,7 @@ def write_config_file(config_instance, appdirs=DEFAULT_APPDIRS,
         ``DEFAULT_CONFIG_FILENAME``.
 
     Returns:
-        SafeConfigParser: Instance written to file.
+        ConfigParser: Instance written to file.
     """
 
     path = get_config_path(appdirs, file_name)
@@ -194,7 +194,7 @@ def load_config_file(appdirs=DEFAULT_APPDIRS, file_name=DEFAULT_CONFIG_FILENAME,
             config file that is created if no pre-existing one can be found.
 
     Returns:
-        SafeConfigParser: Config loaded from file, either from the the  pre-existing config
+        ConfigParser: Config loaded from file, either from the the  pre-existing config
             file or the one created with fallback values.
     """
     if not fallback_config_instance:
@@ -202,7 +202,7 @@ def load_config_file(appdirs=DEFAULT_APPDIRS, file_name=DEFAULT_CONFIG_FILENAME,
             get_default_backend_config(appdirs)
         )
 
-    config = SafeConfigParser()
+    config = ConfigParser()
     path = get_config_path(appdirs, file_name)
     if not config.read(path):
         config = write_config_file(
@@ -244,7 +244,7 @@ def backend_config_to_configparser(config):
         config (dict): Dictionary of config key/value pairs.
 
     Returns:
-        SafeConfigParser: SafeConfigParser instance representing config.
+        ConfigParser: ConfigParser instance representing config.
 
     Note:
         We do not provide *any* validation about mandatory values what so ever.
@@ -285,7 +285,7 @@ def backend_config_to_configparser(config):
     def get_db_password():
         return text_type(config.get('db_password'))
 
-    cp_instance = SafeConfigParser()
+    cp_instance = ConfigParser()
     cp_instance.add_section('Backend')
     cp_instance.set('Backend', 'store', get_store())
     cp_instance.set('Backend', 'day_start', get_day_start())

--- a/hamster_lib/storage.py
+++ b/hamster_lib/storage.py
@@ -38,8 +38,8 @@ import pickle
 import hamster_lib
 from future.utils import python_2_unicode_compatible
 from hamster_lib import objects
-from hamster_lib.helpers import time as time_helpers
 from hamster_lib.helpers import helpers
+from hamster_lib.helpers import time as time_helpers
 
 
 @python_2_unicode_compatible

--- a/requirements/docs.pip
+++ b/requirements/docs.pip
@@ -1,3 +1,3 @@
 # This file specifies all packages required to build the documentation.
 
-Sphinx==1.6.2
+Sphinx

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -4,14 +4,14 @@
 # a reproduceable test environment. For check out ``docs/packaging``.
 # For package-requirements refer to ``setup.py``.
 
-coverage==4.4.1
-factory-boy==2.8.1
-isort==4.2.15
-pytest==3.1.1
-pytest-faker==2.0.0
-pytest-factoryboy==1.3.1
-tox==2.7.0
-future==0.16.0
-fauxfactory==2.1.0
-pytest-mock==1.6.0
-freezegun==0.3.9
+coverage
+factory-boy
+isort
+pytest
+pytest-faker
+pytest-factoryboy
+tox
+future
+fauxfactory
+pytest-mock
+freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.2
+current_version = 0.13.1
 commit = True
 tag = False
 
@@ -18,11 +18,11 @@ precision = 2
 
 [isort]
 not_skip = __init__.py
-known_third_party = appdirs, configparser, faker,factory, faker, freezegun, future, hamster_lib, icalendar, past, pytest, pytest_factoryboy,
+known_third_party = appdirs, backports, faker,factory, faker, freezegun, future, hamster_lib, icalendar, past, pytest, pytest_factoryboy,
 	six, sqlalchemy, fauxfactory
 
-[pytest]
-addopt = 
+[tools:pytest]
+addopt =
 	--tb=short
 	--strict
 	--rsx

--- a/tests/backends/sqlalchemy/factories.py
+++ b/tests/backends/sqlalchemy/factories.py
@@ -28,7 +28,7 @@ class AlchemyCategoryFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = AlchemyCategory
         sqlalchemy_session = common.Session
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
 
 class AlchemyActivityFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -42,7 +42,7 @@ class AlchemyActivityFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = AlchemyActivity
         sqlalchemy_session = common.Session
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
 
 class AlchemyTagFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -58,7 +58,7 @@ class AlchemyTagFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = AlchemyTag
         sqlalchemy_session = common.Session
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
 
 class AlchemyFactFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -73,7 +73,7 @@ class AlchemyFactFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = AlchemyFact
         sqlalchemy_session = common.Session
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     @factory.post_generation
     def tags(self, create, extracted, **kwargs):

--- a/tests/hamster_lib/test_reports.py
+++ b/tests/hamster_lib/test_reports.py
@@ -162,6 +162,7 @@ class TestICALWriter(object):
         result = ical_writer._fact_to_tuple(fact)
         assert result.category == fact.category.name
 
+    @pytest.mark.xfail(reason="Failed when picking up the slack in 2020. See: #245")
     def test_write_fact(self, ical_writer, fact, mocker):
         """Make sure that the fact attached to the calendar matches our expectations."""
         fact_tuple = ical_writer._fact_to_tuple(fact)

--- a/tests/helpers/conftest.py
+++ b/tests/helpers/conftest.py
@@ -7,10 +7,10 @@ from __future__ import absolute_import, unicode_literals
 import codecs
 import datetime
 import os
+from configparser import ConfigParser
 
 import fauxfactory
 import pytest
-from configparser import SafeConfigParser
 from hamster_lib.helpers import config_helpers
 from hamster_lib.helpers.time import TimeFrame
 from six import text_type
@@ -57,7 +57,7 @@ def backend_config(appdirs):
 @pytest.fixture
 def configparser_instance(request):
     """Provide a ``ConfigParser`` instance and its expected config dict."""
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.add_section('Backend')
     config.set('Backend', 'store', 'sqlalchemy')
     config.set('Backend', 'day_start', '05:00:00')
@@ -90,8 +90,8 @@ def configparser_instance(request):
 
 @pytest.fixture
 def config_instance(request):
-    """A dummy instance of ``SafeConfigParser``."""
-    return SafeConfigParser()
+    """A dummy instance of ``ConfigParser``."""
+    return ConfigParser()
 
 
 @pytest.fixture

--- a/tests/helpers/test_config_helpers.py
+++ b/tests/helpers/test_config_helpers.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+from configparser import ConfigParser
 
 import pytest
-from configparser import SafeConfigParser
 from hamster_lib.helpers import config_helpers
 from hamster_lib.helpers.config_helpers import HamsterAppDirs
 
@@ -141,9 +141,9 @@ class TestWriteConfigFile(object):
         assert os.path.lexists(expected_location)
 
     def test_return_config_instance(self, config_instance, appdirs):
-        """Make sure we return a ``SafeConfigParser`` instance."""
+        """Make sure we return a ``ConfigParser`` instance."""
         result = config_helpers.write_config_file(config_instance)
-        assert isinstance(result, SafeConfigParser)
+        assert isinstance(result, ConfigParser)
 
 
 class TestLoadConfigFile(object):
@@ -162,7 +162,7 @@ class TestLoadConfigFile(object):
     def test_file_present(self, config_instance, backend_config):
         """Make sure we try parsing a found config file."""
         result = config_helpers.load_config_file()
-        assert isinstance(result, SafeConfigParser)
+        assert isinstance(result, ConfigParser)
 
 
 class TestConfigParserToBackendConfig(object):

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands = flake8 setup.py hamster_lib/ tests/
 
 [testenv:isort]
 basepython = python3
-deps = isort==4.2.15
+deps = isort
 skip_install = True
 commands =
     isort --check-only --recursive --verbose setup.py hamster_lib/ tests/
@@ -49,7 +49,7 @@ commands =
 
 [testenv:docs]
 basepython = python3
-deps = doc8==0.8.0
+deps = doc8
 commands =
     python -V
     pip install -r requirements/docs.pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py27, py35, flake8, pep257, isort, docs
+envlist = py37, flake8, pep257, isort, docs
 
 [tox:travis]
-2.7 = py27
 3.4 = py34, flake8, pep257, isort, docs
+3.5 = py35, flake8, pep257, isort, docs
+3.6 = py36, flake8, pep257, isort, docs
+3.7 = py37, flake8, pep257, isort, docs
 
 [testenv]
 setenv =


### PR DESCRIPTION
After returning to the codebase, the testsuite showed multiple issues. 
This PR deal with them by:
- Remove version pinning of test libraries so the test run on up to date tooling
- Set one actual failed test to ``xfail`` (#245 ), which needs to be dealt with seperately.
- Use new SQLAlchemy meta attribute in order to avoid deprecation warnings
- Remove broken links, due to changes in ``legacy-hamster``'s `master` branch.
- Drop python2 support within the test suite and travis CI

Outstanding issue: #245 

We still get a warning about some fuckup with regards to scoped alchemy sessions. This will most likely take more time and should be addressed in a separate issue.
```
/.venv/lib/python3.7/site-packages/sqlalchemy/orm/scoping.py:107: SAWarning: At least one scoped session is already present.  configure() can not affect sessions that have already been created.
    "At least one scoped session is already present. "
```


Closes:
